### PR TITLE
feat: enhance network and meeting statistics display

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ set(SOURCES
     main.cpp
     # Core modules
     core/conference/conference_manager.cpp
+    core/conference/network_stats_aggregator.cpp
     core/conference/participant_store.cpp
     core/conference/media_pipeline.cpp
     core/conference/device_controller.cpp
@@ -110,6 +111,7 @@ set(HEADERS
     # Core modules
     core/conference/conference_manager.h
     core/conference/conference_types.h
+    core/conference/network_stats_aggregator.h
     core/conference/participant_store.h
     core/conference/media_pipeline.h
     core/conference/device_controller.h

--- a/core/conference/conference_manager.cpp
+++ b/core/conference/conference_manager.cpp
@@ -9,10 +9,35 @@
 #include <QStringList>
 #include <QTimer>
 #include <algorithm>
+#include <cmath>
+#include <unordered_set>
 #include <vector>
 #include "livekit/audio_stream.h"
+#include "livekit/local_participant.h"
 #include "livekit/remote_participant.h"
+#include "livekit/track.h"
 #include "livekit/video_stream.h"
+
+namespace {
+
+bool networkStatsEquivalent(const NetworkStatsSnapshot& lhs,
+                            const NetworkStatsSnapshot& rhs)
+{
+    return lhs.rttMs == rhs.rttMs
+        && lhs.jitterMs == rhs.jitterMs
+        && lhs.uplinkKbps == rhs.uplinkKbps
+        && lhs.downlinkKbps == rhs.downlinkKbps
+        && std::fabs(lhs.packetLossPercent - rhs.packetLossPercent) < 0.001
+        && lhs.videoWidth == rhs.videoWidth
+        && lhs.videoHeight == rhs.videoHeight
+        && std::fabs(lhs.videoFps - rhs.videoFps) < 0.1
+        && lhs.audioCodec == rhs.audioCodec
+        && lhs.videoCodec == rhs.videoCodec
+        && lhs.availableSendBandwidthKbps == rhs.availableSendBandwidthKbps
+        && lhs.transportProtocol == rhs.transportProtocol;
+}
+
+} // namespace
 
 ConferenceManager::ConferenceManager(QObject* parent)
     : QObject(parent),
@@ -25,6 +50,7 @@ ConferenceManager::ConferenceManager(QObject* parent)
     Logger::instance().info("ConferenceManager created");
     qRegisterMetaType<livekit::TrackSource>("livekit::TrackSource");
     qRegisterMetaType<livekit::TrackKind>("livekit::TrackKind");
+    qRegisterMetaType<NetworkStatsSnapshot>("NetworkStatsSnapshot");
 
     roomController_->setDelegate(roomDelegate_.get());
 
@@ -42,6 +68,8 @@ ConferenceManager::ConferenceManager(QObject* parent)
                      this, &ConferenceManager::onTrackUnmutedQueued);
     QObject::connect(roomDelegate_.get(), &RoomEventDelegate::trackUnpublishedQueued,
                      this, &ConferenceManager::onTrackUnpublishedQueued);
+    QObject::connect(roomDelegate_.get(), &RoomEventDelegate::connectionQualityChangedQueued,
+                     this, &ConferenceManager::onConnectionQualityChangedQueued);
     QObject::connect(roomDelegate_.get(), &RoomEventDelegate::connectionStateChangedQueued,
                      this, &ConferenceManager::onConnectionStateChangedQueued);
     QObject::connect(roomDelegate_.get(), &RoomEventDelegate::dataReceivedQueued,
@@ -69,6 +97,11 @@ ConferenceManager::ConferenceManager(QObject* parent)
         [this](const int16_t* data, int samples, int sampleRate, int channels) {
             feedReverseAudio(data, samples, sampleRate, channels);
         });
+
+    networkStatsTimer_.setInterval(1000);
+    networkStatsTimer_.setSingleShot(false);
+    QObject::connect(&networkStatsTimer_, &QTimer::timeout,
+                     this, &ConferenceManager::pollLocalNetworkStats);
 }
 
 ConferenceManager::~ConferenceManager()
@@ -130,6 +163,11 @@ void ConferenceManager::disconnect()
         connected_ = false;
         participantStore_->clear();
         participantIdentity_.clear();
+        networkStatsTimer_.stop();
+        resetNetworkMetrics();
+
+        emit localConnectionQualityChanged(static_cast<int>(localNetworkQuality_));
+        emit localNetworkStatsUpdated(localNetworkStats_);
 
         emit disconnected();
     } catch (const std::exception& e) {
@@ -483,6 +521,42 @@ void ConferenceManager::onTrackUnpublishedQueued(QString trackSid, QString parti
     reconcileParticipantsInternal("track_unpublished_event");
 }
 
+void ConferenceManager::onConnectionQualityChangedQueued(QString participantIdentity, int quality)
+{
+    if (participantIdentity.trimmed().isEmpty()) {
+        return;
+    }
+
+    const QString localIdentity = resolveLocalParticipantIdentity();
+    if (localIdentity.isEmpty() || participantIdentity != localIdentity) {
+        return;
+    }
+
+    const auto mappedQuality =
+        toNetworkQualityLevel(static_cast<livekit::ConnectionQuality>(quality));
+    if (mappedQuality == localNetworkQuality_) {
+        return;
+    }
+
+    localNetworkQuality_ = mappedQuality;
+    emit localConnectionQualityChanged(static_cast<int>(localNetworkQuality_));
+
+    if (!hasNetworkStatsData(localNetworkStats_) || usingEstimatedNetworkStats_) {
+        const NetworkStatsSnapshot estimated =
+            buildEstimatedNetworkSnapshot(localNetworkQuality_, QDateTime::currentMSecsSinceEpoch());
+        usingEstimatedNetworkStats_ = true;
+        if (!networkStatsEquivalent(localNetworkStats_, estimated)) {
+            localNetworkStats_ = estimated;
+            Logger::instance().debug(
+                QString("Estimated network stats applied from quality: rtt=%1ms, jitter=%2ms, loss=%3%")
+                    .arg(localNetworkStats_.rttMs)
+                    .arg(localNetworkStats_.jitterMs)
+                    .arg(localNetworkStats_.packetLossPercent, 0, 'f', 1));
+            emit localNetworkStatsUpdated(localNetworkStats_);
+        }
+    }
+}
+
 void ConferenceManager::onConnectionStateChangedQueued(int state)
 {
     livekit::ConnectionState connState = static_cast<livekit::ConnectionState>(state);
@@ -501,12 +575,25 @@ void ConferenceManager::onConnectionStateChangedQueued(int state)
         }
 
         reconcileParticipantsInternal("connection_connected_state");
+        if (!networkStatsTimer_.isActive()) {
+            networkStatsTimer_.start();
+        }
+        pollLocalNetworkStats();
 
         emit connected();
+    } else if (connState == livekit::ConnectionState::Reconnecting) {
+        networkStatsTimer_.stop();
+        resetNetworkMetrics();
+        emit localConnectionQualityChanged(static_cast<int>(localNetworkQuality_));
+        emit localNetworkStatsUpdated(localNetworkStats_);
     } else if (connState == livekit::ConnectionState::Disconnected) {
         connected_ = false;
         participantStore_->clear();
         participantIdentity_.clear();
+        networkStatsTimer_.stop();
+        resetNetworkMetrics();
+        emit localConnectionQualityChanged(static_cast<int>(localNetworkQuality_));
+        emit localNetworkStatsUpdated(localNetworkStats_);
         emit disconnected();
     }
 
@@ -641,4 +728,182 @@ void ConferenceManager::reconcileParticipantsInternal(const char* source)
         }
         Logger::instance().info(message);
     }
+}
+
+void ConferenceManager::pollLocalNetworkStats()
+{
+    if (!connected_ || !roomController_ || !roomController_->room()) {
+        return;
+    }
+
+    const auto tracks = collectTrackStatsSources();
+    const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+    if (tracks.empty()) {
+        previousNetworkByteCounters_ = NetworkByteCounters{};
+        if (!usingEstimatedNetworkStats_) {
+            NetworkStatsSnapshot snapshot;
+            snapshot.sampledAtMs = nowMs;
+            if (!networkStatsEquivalent(snapshot, localNetworkStats_)) {
+                localNetworkStats_ = snapshot;
+                emit localNetworkStatsUpdated(localNetworkStats_);
+            }
+        }
+        return;
+    }
+
+    std::vector<livekit::RtcStats> aggregatedStats;
+    for (const auto& track : tracks) {
+        if (!track) {
+            continue;
+        }
+
+        try {
+            auto statsFuture = track->getStats();
+            std::vector<livekit::RtcStats> stats = statsFuture.get();
+            aggregatedStats.insert(aggregatedStats.end(), stats.begin(), stats.end());
+        } catch (const std::exception& e) {
+            Logger::instance().warning(QString("Failed to collect track stats: %1").arg(e.what()));
+        }
+    }
+
+    if (aggregatedStats.empty()) {
+        return;
+    }
+
+    const NetworkStatsAggregationResult aggregated =
+        aggregateNetworkStats(aggregatedStats, previousNetworkByteCounters_, nowMs);
+    previousNetworkByteCounters_ = aggregated.counters;
+
+    // Grace period: keep estimated stats for the first 5 seconds after connection
+    // to avoid a visual "blip" to empty values. After that, always use real data.
+    const bool withinGracePeriod = usingEstimatedNetworkStats_
+        && (nowMs - localNetworkStats_.sampledAtMs) < 5000;
+    if (!hasNetworkStatsData(aggregated.snapshot) && withinGracePeriod) {
+        return;
+    }
+    usingEstimatedNetworkStats_ = false;
+
+    if (!networkStatsEquivalent(localNetworkStats_, aggregated.snapshot)) {
+        localNetworkStats_ = aggregated.snapshot;
+        Logger::instance().debug(
+            QString("LiveKit network stats updated: rtt=%1ms, jitter=%2ms, loss=%3%, up=%4kbps, down=%5kbps, "
+                    "bw=%6kbps, proto=%7, video=%8x%9@%10fps, acodec=%11, vcodec=%12")
+                .arg(localNetworkStats_.rttMs)
+                .arg(localNetworkStats_.jitterMs)
+                .arg(localNetworkStats_.packetLossPercent, 0, 'f', 1)
+                .arg(localNetworkStats_.uplinkKbps)
+                .arg(localNetworkStats_.downlinkKbps)
+                .arg(localNetworkStats_.availableSendBandwidthKbps)
+                .arg(localNetworkStats_.transportProtocol.isEmpty() ? QStringLiteral("none") : localNetworkStats_.transportProtocol)
+                .arg(localNetworkStats_.videoWidth)
+                .arg(localNetworkStats_.videoHeight)
+                .arg(localNetworkStats_.videoFps, 0, 'f', 1)
+                .arg(localNetworkStats_.audioCodec.isEmpty() ? QStringLiteral("none") : localNetworkStats_.audioCodec)
+                .arg(localNetworkStats_.videoCodec.isEmpty() ? QStringLiteral("none") : localNetworkStats_.videoCodec));
+        emit localNetworkStatsUpdated(localNetworkStats_);
+    }
+}
+
+QString ConferenceManager::resolveLocalParticipantIdentity() const
+{
+    if (!participantIdentity_.isEmpty()) {
+        return participantIdentity_;
+    }
+
+    if (!roomController_ || !roomController_->localParticipant()) {
+        return {};
+    }
+
+    return QString::fromStdString(roomController_->localParticipant()->identity());
+}
+
+std::vector<std::shared_ptr<livekit::Track>> ConferenceManager::collectTrackStatsSources() const
+{
+    std::vector<std::shared_ptr<livekit::Track>> tracks;
+    if (!roomController_ || !roomController_->room()) {
+        return tracks;
+    }
+
+    std::unordered_set<std::string> collectedTrackSids;
+    auto appendTrack = [&](const std::shared_ptr<livekit::Track>& track) {
+        if (!track) {
+            return;
+        }
+
+        const std::string sid = track->sid();
+        if (sid.empty()) {
+            return;
+        }
+
+        if (collectedTrackSids.insert(sid).second) {
+            tracks.push_back(track);
+        }
+    };
+
+    if (auto* localParticipant = roomController_->localParticipant()) {
+        for (const auto& publicationEntry : localParticipant->trackPublications()) {
+            const auto& publication = publicationEntry.second;
+            if (!publication) {
+                continue;
+            }
+            appendTrack(publication->track());
+        }
+    }
+
+    const auto remoteParticipants = roomController_->remoteParticipants();
+    for (const auto& participant : remoteParticipants) {
+        if (!participant) {
+            continue;
+        }
+
+        for (const auto& publicationEntry : participant->trackPublications()) {
+            const auto& publication = publicationEntry.second;
+            if (!publication) {
+                continue;
+            }
+            appendTrack(publication->track());
+        }
+    }
+
+    return tracks;
+}
+
+NetworkStatsSnapshot ConferenceManager::buildEstimatedNetworkSnapshot(
+    NetworkQualityLevel quality,
+    qint64 nowMs) const
+{
+    NetworkStatsSnapshot snapshot;
+    snapshot.sampledAtMs = nowMs;
+
+    switch (quality) {
+        case NetworkQualityLevel::Excellent:
+            snapshot.rttMs = 60;
+            snapshot.jitterMs = 8;
+            snapshot.packetLossPercent = 0.2;
+            break;
+        case NetworkQualityLevel::Good:
+            snapshot.rttMs = 120;
+            snapshot.jitterMs = 18;
+            snapshot.packetLossPercent = 1.0;
+            break;
+        case NetworkQualityLevel::Poor:
+            snapshot.rttMs = 260;
+            snapshot.jitterMs = 45;
+            snapshot.packetLossPercent = 4.0;
+            break;
+        case NetworkQualityLevel::Lost:
+        case NetworkQualityLevel::Unknown:
+        default:
+            break;
+    }
+
+    return snapshot;
+}
+
+void ConferenceManager::resetNetworkMetrics()
+{
+    localNetworkQuality_ = NetworkQualityLevel::Unknown;
+    localNetworkStats_ = NetworkStatsSnapshot{};
+    previousNetworkByteCounters_ = NetworkByteCounters{};
+    usingEstimatedNetworkStats_ = false;
 }

--- a/core/conference/conference_manager.cpp
+++ b/core/conference/conference_manager.cpp
@@ -1,6 +1,7 @@
 #include "conference_manager.h"
 #include "../room_event_delegate.h"
 #include "../../utils/logger.h"
+#include <QFutureWatcher>
 #include <QDateTime>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -8,6 +9,7 @@
 #include <QSet>
 #include <QStringList>
 #include <QTimer>
+#include <QtConcurrent/QtConcurrentRun>
 #include <algorithm>
 #include <cmath>
 #include <unordered_set>
@@ -19,6 +21,11 @@
 #include "livekit/video_stream.h"
 
 namespace {
+
+struct AsyncNetworkPollResult {
+    bool hasData{false};
+    NetworkStatsAggregationResult aggregation;
+};
 
 bool networkStatsEquivalent(const NetworkStatsSnapshot& lhs,
                             const NetworkStatsSnapshot& rhs)
@@ -738,6 +745,31 @@ void ConferenceManager::pollLocalNetworkStats()
 
     const auto tracks = collectTrackStatsSources();
     const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+    QSet<QString> currentTrackSids;
+    currentTrackSids.reserve(static_cast<int>(tracks.size()));
+    for (const auto& track : tracks) {
+        if (!track) {
+            continue;
+        }
+
+        const QString sid = QString::fromStdString(track->sid());
+        if (!sid.isEmpty()) {
+            currentTrackSids.insert(sid);
+        }
+    }
+
+    const bool trackSetChanged = (currentTrackSids != lastPolledTrackSids_);
+    if (trackSetChanged) {
+        lastPolledTrackSids_ = currentTrackSids;
+        previousNetworkByteCounters_ = NetworkByteCounters{};
+
+        // Invalidate in-flight results derived from a different track set.
+        if (networkStatsPollInFlight_) {
+            ++networkStatsPollSeq_;
+            networkStatsPollInFlight_ = false;
+        }
+    }
+
     if (tracks.empty()) {
         previousNetworkByteCounters_ = NetworkByteCounters{};
         if (!usingEstimatedNetworkStats_) {
@@ -751,57 +783,105 @@ void ConferenceManager::pollLocalNetworkStats()
         return;
     }
 
-    std::vector<livekit::RtcStats> aggregatedStats;
-    for (const auto& track : tracks) {
-        if (!track) {
-            continue;
-        }
+    if (networkStatsPollInFlight_) {
+        return;
+    }
 
+    const NetworkByteCounters baselineCounters = previousNetworkByteCounters_;
+    const quint64 pollSeq = ++networkStatsPollSeq_;
+    networkStatsPollInFlight_ = true;
+
+    auto* watcher = new QFutureWatcher<AsyncNetworkPollResult>(this);
+    QObject::connect(watcher, &QFutureWatcher<AsyncNetworkPollResult>::finished,
+                     this, [this, watcher, pollSeq]() {
+        AsyncNetworkPollResult asyncResult;
         try {
-            auto statsFuture = track->getStats();
-            std::vector<livekit::RtcStats> stats = statsFuture.get();
-            aggregatedStats.insert(aggregatedStats.end(), stats.begin(), stats.end());
+            asyncResult = watcher->result();
         } catch (const std::exception& e) {
-            Logger::instance().warning(QString("Failed to collect track stats: %1").arg(e.what()));
+            Logger::instance().warning(QString("Asynchronous network stats polling failed: %1")
+                                       .arg(e.what()));
+        } catch (...) {
+            Logger::instance().warning("Asynchronous network stats polling failed with unknown error");
         }
-    }
+        watcher->deleteLater();
 
-    if (aggregatedStats.empty()) {
-        return;
-    }
+        if (pollSeq != networkStatsPollSeq_) {
+            return;
+        }
 
-    const NetworkStatsAggregationResult aggregated =
-        aggregateNetworkStats(aggregatedStats, previousNetworkByteCounters_, nowMs);
-    previousNetworkByteCounters_ = aggregated.counters;
+        networkStatsPollInFlight_ = false;
+        if (!connected_ || !roomController_ || !roomController_->room()) {
+            return;
+        }
 
-    // Grace period: keep estimated stats for the first 5 seconds after connection
-    // to avoid a visual "blip" to empty values. After that, always use real data.
-    const bool withinGracePeriod = usingEstimatedNetworkStats_
-        && (nowMs - localNetworkStats_.sampledAtMs) < 5000;
-    if (!hasNetworkStatsData(aggregated.snapshot) && withinGracePeriod) {
-        return;
-    }
-    usingEstimatedNetworkStats_ = false;
+        if (!asyncResult.hasData) {
+            return;
+        }
 
-    if (!networkStatsEquivalent(localNetworkStats_, aggregated.snapshot)) {
-        localNetworkStats_ = aggregated.snapshot;
-        Logger::instance().debug(
-            QString("LiveKit network stats updated: rtt=%1ms, jitter=%2ms, loss=%3%, up=%4kbps, down=%5kbps, "
-                    "bw=%6kbps, proto=%7, video=%8x%9@%10fps, acodec=%11, vcodec=%12")
-                .arg(localNetworkStats_.rttMs)
-                .arg(localNetworkStats_.jitterMs)
-                .arg(localNetworkStats_.packetLossPercent, 0, 'f', 1)
-                .arg(localNetworkStats_.uplinkKbps)
-                .arg(localNetworkStats_.downlinkKbps)
-                .arg(localNetworkStats_.availableSendBandwidthKbps)
-                .arg(localNetworkStats_.transportProtocol.isEmpty() ? QStringLiteral("none") : localNetworkStats_.transportProtocol)
-                .arg(localNetworkStats_.videoWidth)
-                .arg(localNetworkStats_.videoHeight)
-                .arg(localNetworkStats_.videoFps, 0, 'f', 1)
-                .arg(localNetworkStats_.audioCodec.isEmpty() ? QStringLiteral("none") : localNetworkStats_.audioCodec)
-                .arg(localNetworkStats_.videoCodec.isEmpty() ? QStringLiteral("none") : localNetworkStats_.videoCodec));
-        emit localNetworkStatsUpdated(localNetworkStats_);
-    }
+        const NetworkStatsAggregationResult& aggregated = asyncResult.aggregation;
+        previousNetworkByteCounters_ = aggregated.counters;
+
+        // Grace period: keep estimated stats for the first 5 seconds after connection
+        // to avoid a visual "blip" to empty values. After that, always use real data.
+        const qint64 now = QDateTime::currentMSecsSinceEpoch();
+        const bool withinGracePeriod = usingEstimatedNetworkStats_
+            && (now - localNetworkStats_.sampledAtMs) < 5000;
+        if (!hasNetworkStatsData(aggregated.snapshot) && withinGracePeriod) {
+            return;
+        }
+        usingEstimatedNetworkStats_ = false;
+
+        if (!networkStatsEquivalent(localNetworkStats_, aggregated.snapshot)) {
+            localNetworkStats_ = aggregated.snapshot;
+            Logger::instance().debug(
+                QString("LiveKit network stats updated: rtt=%1ms, jitter=%2ms, loss=%3%, up=%4kbps, down=%5kbps, "
+                        "bw=%6kbps, proto=%7, video=%8x%9@%10fps, acodec=%11, vcodec=%12")
+                    .arg(localNetworkStats_.rttMs)
+                    .arg(localNetworkStats_.jitterMs)
+                    .arg(localNetworkStats_.packetLossPercent, 0, 'f', 1)
+                    .arg(localNetworkStats_.uplinkKbps)
+                    .arg(localNetworkStats_.downlinkKbps)
+                    .arg(localNetworkStats_.availableSendBandwidthKbps)
+                    .arg(localNetworkStats_.transportProtocol.isEmpty()
+                        ? QStringLiteral("none") : localNetworkStats_.transportProtocol)
+                    .arg(localNetworkStats_.videoWidth)
+                    .arg(localNetworkStats_.videoHeight)
+                    .arg(localNetworkStats_.videoFps, 0, 'f', 1)
+                    .arg(localNetworkStats_.audioCodec.isEmpty()
+                        ? QStringLiteral("none") : localNetworkStats_.audioCodec)
+                    .arg(localNetworkStats_.videoCodec.isEmpty()
+                        ? QStringLiteral("none") : localNetworkStats_.videoCodec));
+            emit localNetworkStatsUpdated(localNetworkStats_);
+        }
+    });
+
+    QFuture<AsyncNetworkPollResult> future = QtConcurrent::run(
+        [tracks, baselineCounters, nowMs]() -> AsyncNetworkPollResult {
+            AsyncNetworkPollResult result;
+            std::vector<livekit::RtcStats> aggregatedStats;
+            for (const auto& track : tracks) {
+                if (!track) {
+                    continue;
+                }
+
+                try {
+                    auto statsFuture = track->getStats();
+                    std::vector<livekit::RtcStats> stats = statsFuture.get();
+                    aggregatedStats.insert(aggregatedStats.end(), stats.begin(), stats.end());
+                } catch (...) {
+                    // Ignore individual track failures to keep polling robust.
+                }
+            }
+
+            if (aggregatedStats.empty()) {
+                return result;
+            }
+
+            result.hasData = true;
+            result.aggregation = aggregateNetworkStats(aggregatedStats, baselineCounters, nowMs);
+            return result;
+        });
+    watcher->setFuture(future);
 }
 
 QString ConferenceManager::resolveLocalParticipantIdentity() const
@@ -906,4 +986,7 @@ void ConferenceManager::resetNetworkMetrics()
     localNetworkStats_ = NetworkStatsSnapshot{};
     previousNetworkByteCounters_ = NetworkByteCounters{};
     usingEstimatedNetworkStats_ = false;
+    networkStatsPollInFlight_ = false;
+    ++networkStatsPollSeq_;
+    lastPolledTrackSids_.clear();
 }

--- a/core/conference/conference_manager.h
+++ b/core/conference/conference_manager.h
@@ -7,7 +7,9 @@
 #include <QImage>
 #include <QList>
 #include <memory>
+#include <vector>
 #include "conference_types.h"
+#include "network_stats_aggregator.h"
 #include "room_controller.h"
 #include "participant_store.h"
 #include "media_pipeline.h"
@@ -110,6 +112,8 @@ signals:
                             const QImage& frame,
                             livekit::TrackSource source);
     void audioActivity(const QString& participantIdentity, bool hasAudio);
+    void localConnectionQualityChanged(int quality);
+    void localNetworkStatsUpdated(const NetworkStatsSnapshot& stats);
     
 private:
     // Queued slots for RoomEventDelegate signals (thread-safe event handling)
@@ -123,11 +127,17 @@ private:
     void onTrackMutedQueued(QString trackSid, QString participantIdentity, int kind);
     void onTrackUnmutedQueued(QString trackSid, QString participantIdentity, int kind);
     void onTrackUnpublishedQueued(QString trackSid, QString participantIdentity, int kind, int source);
+    void onConnectionQualityChangedQueued(QString participantIdentity, int quality);
     void onConnectionStateChangedQueued(int state);
     void onDataReceivedQueued(QByteArray data, QString participantIdentity, QString topic);
     
     void updateParticipantInfo(const QString& identity);
     void reconcileParticipantsInternal(const char* source);
+    void pollLocalNetworkStats();
+    QString resolveLocalParticipantIdentity() const;
+    std::vector<std::shared_ptr<livekit::Track>> collectTrackStatsSources() const;
+    NetworkStatsSnapshot buildEstimatedNetworkSnapshot(NetworkQualityLevel quality, qint64 nowMs) const;
+    void resetNetworkMetrics();
 
     std::unique_ptr<RoomController> roomController_;
     std::unique_ptr<RoomEventDelegate> roomDelegate_;
@@ -139,6 +149,11 @@ private:
     QString participantName_;
     QString participantIdentity_;
     bool connected_{false};
+    QTimer networkStatsTimer_;
+    NetworkQualityLevel localNetworkQuality_{NetworkQualityLevel::Unknown};
+    NetworkStatsSnapshot localNetworkStats_;
+    NetworkByteCounters previousNetworkByteCounters_;
+    bool usingEstimatedNetworkStats_{false};
 };
 
 #endif // CORE_CONFERENCE_CONFERENCE_MANAGER_H

--- a/core/conference/conference_manager.h
+++ b/core/conference/conference_manager.h
@@ -6,6 +6,7 @@
 #include <QByteArray>
 #include <QImage>
 #include <QList>
+#include <QSet>
 #include <memory>
 #include <vector>
 #include "conference_types.h"
@@ -154,6 +155,9 @@ private:
     NetworkStatsSnapshot localNetworkStats_;
     NetworkByteCounters previousNetworkByteCounters_;
     bool usingEstimatedNetworkStats_{false};
+    bool networkStatsPollInFlight_{false};
+    quint64 networkStatsPollSeq_{0};
+    QSet<QString> lastPolledTrackSids_;
 };
 
 #endif // CORE_CONFERENCE_CONFERENCE_MANAGER_H

--- a/core/conference/conference_types.h
+++ b/core/conference/conference_types.h
@@ -2,6 +2,8 @@
 #define CORE_CONFERENCE_CONFERENCE_TYPES_H
 
 #include <QString>
+#include <QMetaType>
+#include <cstdint>
 #include <memory>
 #include "livekit/livekit.h"
 
@@ -23,6 +25,32 @@ struct ChatMessage {
     bool isLocal;
 };
 
+enum class NetworkQualityLevel {
+    Unknown = 0,
+    Poor,
+    Good,
+    Excellent,
+    Lost,
+};
+
+struct NetworkStatsSnapshot {
+    int rttMs{-1};
+    int jitterMs{-1};
+    double packetLossPercent{-1.0};
+    int uplinkKbps{-1};
+    int downlinkKbps{-1};
+    std::int64_t sampledAtMs{0};
+
+    // Extended fields (populated from RTC stats when available)
+    int videoWidth{0};
+    int videoHeight{0};
+    double videoFps{-1.0};
+    QString audioCodec;
+    QString videoCodec;
+    int availableSendBandwidthKbps{-1};
+    QString transportProtocol;
+};
+
 struct TrackInfo {
     QString trackSid;
     QString participantIdentity;
@@ -31,5 +59,7 @@ struct TrackInfo {
     bool isLocal;
     std::shared_ptr<livekit::Track> track;
 };
+
+Q_DECLARE_METATYPE(NetworkStatsSnapshot)
 
 #endif // CORE_CONFERENCE_CONFERENCE_TYPES_H

--- a/core/conference/network_stats_aggregator.cpp
+++ b/core/conference/network_stats_aggregator.cpp
@@ -1,0 +1,215 @@
+#include "network_stats_aggregator.h"
+
+#include <algorithm>
+#include <cmath>
+#include <type_traits>
+#include <variant>
+#include <QString>
+
+namespace {
+
+int toRoundedInt(double value)
+{
+    return static_cast<int>(std::lround(value));
+}
+
+void accumulateRttMs(double seconds, double& rttSumMs, int& rttSamples)
+{
+    if (std::isfinite(seconds) && seconds > 0.0) {
+        rttSumMs += seconds * 1000.0;
+        ++rttSamples;
+    }
+}
+
+void accumulateJitterMs(double seconds, double& jitterSumMs, int& jitterSamples)
+{
+    if (std::isfinite(seconds) && seconds >= 0.0) {
+        jitterSumMs += seconds * 1000.0;
+        ++jitterSamples;
+    }
+}
+
+} // namespace
+
+NetworkStatsAggregationResult aggregateNetworkStats(
+    const std::vector<livekit::RtcStats>& stats,
+    const NetworkByteCounters& previousCounters,
+    std::int64_t nowMs)
+{
+    NetworkStatsAggregationResult result;
+    result.snapshot.sampledAtMs = nowMs;
+
+    double rttSumMs = 0.0;
+    int rttSamples = 0;
+    double jitterSumMs = 0.0;
+    int jitterSamples = 0;
+
+    std::uint64_t bytesSent = 0;
+    std::uint64_t bytesReceived = 0;
+    std::uint64_t packetsReceived = 0;
+    std::uint64_t packetsLost = 0;
+
+    // Extended stats accumulators
+    int bestVideoWidth = 0;
+    int bestVideoHeight = 0;
+    double bestVideoFps = -1.0;
+    QString audioCodec;
+    QString videoCodec;
+    double availableOutgoingBitrate = -1.0;
+    QString transportProtocol;
+
+    for (const livekit::RtcStats& stat : stats) {
+        std::visit(
+            [&](const auto& typedStat) {
+                using T = std::decay_t<decltype(typedStat)>;
+                if constexpr (std::is_same_v<T, livekit::RtcInboundRtpStats>) {
+                    bytesReceived += typedStat.inbound.bytes_received;
+                    packetsReceived += typedStat.received.packets_received;
+                    packetsLost += static_cast<std::uint64_t>(
+                        std::max<std::int64_t>(0, typedStat.received.packets_lost));
+                    accumulateJitterMs(typedStat.received.jitter, jitterSumMs, jitterSamples);
+
+                    // Video resolution & FPS (pick the largest inbound video)
+                    if (typedStat.stream.kind == "video"
+                        && typedStat.inbound.frame_width > 0
+                        && typedStat.inbound.frame_height > 0) {
+                        int pixels = static_cast<int>(typedStat.inbound.frame_width)
+                                     * static_cast<int>(typedStat.inbound.frame_height);
+                        if (pixels > bestVideoWidth * bestVideoHeight) {
+                            bestVideoWidth = static_cast<int>(typedStat.inbound.frame_width);
+                            bestVideoHeight = static_cast<int>(typedStat.inbound.frame_height);
+                        }
+                        if (std::isfinite(typedStat.inbound.frames_per_second)
+                            && typedStat.inbound.frames_per_second > bestVideoFps) {
+                            bestVideoFps = typedStat.inbound.frames_per_second;
+                        }
+                    }
+                } else if constexpr (std::is_same_v<T, livekit::RtcOutboundRtpStats>) {
+                    bytesSent += typedStat.sent.bytes_sent;
+
+                    // Outbound video resolution & FPS (prefer outbound if larger)
+                    if (typedStat.stream.kind == "video"
+                        && typedStat.outbound.frame_width > 0
+                        && typedStat.outbound.frame_height > 0) {
+                        int pixels = static_cast<int>(typedStat.outbound.frame_width)
+                                     * static_cast<int>(typedStat.outbound.frame_height);
+                        if (pixels > bestVideoWidth * bestVideoHeight) {
+                            bestVideoWidth = static_cast<int>(typedStat.outbound.frame_width);
+                            bestVideoHeight = static_cast<int>(typedStat.outbound.frame_height);
+                        }
+                        if (std::isfinite(typedStat.outbound.frames_per_second)
+                            && typedStat.outbound.frames_per_second > bestVideoFps) {
+                            bestVideoFps = typedStat.outbound.frames_per_second;
+                        }
+                    }
+                } else if constexpr (std::is_same_v<T, livekit::RtcRemoteInboundRtpStats>) {
+                    accumulateRttMs(typedStat.remote_inbound.round_trip_time, rttSumMs, rttSamples);
+                } else if constexpr (std::is_same_v<T, livekit::RtcRemoteOutboundRtpStats>) {
+                    accumulateRttMs(typedStat.remote_outbound.round_trip_time, rttSumMs, rttSamples);
+                } else if constexpr (std::is_same_v<T, livekit::RtcCandidatePairStats>) {
+                    accumulateRttMs(typedStat.candidate_pair.current_round_trip_time, rttSumMs, rttSamples);
+                    // Available outgoing bitrate (bps -> kbps)
+                    if (std::isfinite(typedStat.candidate_pair.available_outgoing_bitrate)
+                        && typedStat.candidate_pair.available_outgoing_bitrate > 0.0) {
+                        availableOutgoingBitrate = typedStat.candidate_pair.available_outgoing_bitrate / 1000.0;
+                    }
+                } else if constexpr (std::is_same_v<T, livekit::RtcCodecStats>) {
+                    // Extract codec names (e.g. "audio/opus" -> "opus", "video/VP8" -> "VP8")
+                    const QString mimeType = QString::fromStdString(typedStat.codec.mime_type);
+                    if (mimeType.startsWith("audio/", Qt::CaseInsensitive) && audioCodec.isEmpty()) {
+                        audioCodec = mimeType.mid(6);
+                    } else if (mimeType.startsWith("video/", Qt::CaseInsensitive) && videoCodec.isEmpty()) {
+                        videoCodec = mimeType.mid(6);
+                    }
+                } else if constexpr (std::is_same_v<T, livekit::RtcLocalCandidateStats>) {
+                    // Transport protocol (e.g. "udp", "tcp")
+                    if (transportProtocol.isEmpty() && !typedStat.candidate.protocol.empty()) {
+                        transportProtocol = QString::fromStdString(typedStat.candidate.protocol).toUpper();
+                    }
+                }
+            },
+            stat.stats);
+    }
+
+    if (rttSamples > 0) {
+        result.snapshot.rttMs = toRoundedInt(rttSumMs / static_cast<double>(rttSamples));
+    }
+
+    if (jitterSamples > 0) {
+        result.snapshot.jitterMs = toRoundedInt(jitterSumMs / static_cast<double>(jitterSamples));
+    }
+
+    if (packetsReceived + packetsLost > 0) {
+        const double loss = (static_cast<double>(packetsLost)
+                             / static_cast<double>(packetsReceived + packetsLost)) * 100.0;
+        result.snapshot.packetLossPercent = std::clamp(loss, 0.0, 100.0);
+    }
+
+    if (previousCounters.valid
+        && previousCounters.sampledAtMs > 0
+        && nowMs > previousCounters.sampledAtMs) {
+        const std::int64_t deltaMs = nowMs - previousCounters.sampledAtMs;
+        if (deltaMs >= 500) {
+            if (bytesSent >= previousCounters.bytesSent) {
+                const double uplinkKbps = (static_cast<double>(bytesSent - previousCounters.bytesSent) * 8.0)
+                    / static_cast<double>(deltaMs);
+                result.snapshot.uplinkKbps = std::max(0, toRoundedInt(uplinkKbps));
+            }
+
+            if (bytesReceived >= previousCounters.bytesReceived) {
+                const double downlinkKbps =
+                    (static_cast<double>(bytesReceived - previousCounters.bytesReceived) * 8.0)
+                    / static_cast<double>(deltaMs);
+                result.snapshot.downlinkKbps = std::max(0, toRoundedInt(downlinkKbps));
+            }
+        }
+    }
+
+    // Populate extended fields
+    result.snapshot.videoWidth = bestVideoWidth;
+    result.snapshot.videoHeight = bestVideoHeight;
+    result.snapshot.videoFps = bestVideoFps;
+    result.snapshot.audioCodec = audioCodec;
+    result.snapshot.videoCodec = videoCodec;
+    if (availableOutgoingBitrate >= 0.0) {
+        result.snapshot.availableSendBandwidthKbps = std::max(0, toRoundedInt(availableOutgoingBitrate));
+    }
+    result.snapshot.transportProtocol = transportProtocol;
+
+    result.counters.bytesSent = bytesSent;
+    result.counters.bytesReceived = bytesReceived;
+    result.counters.sampledAtMs = nowMs;
+    result.counters.valid = true;
+
+    return result;
+}
+
+NetworkQualityLevel toNetworkQualityLevel(livekit::ConnectionQuality quality)
+{
+    switch (quality) {
+        case livekit::ConnectionQuality::Poor:
+            return NetworkQualityLevel::Poor;
+        case livekit::ConnectionQuality::Good:
+            return NetworkQualityLevel::Good;
+        case livekit::ConnectionQuality::Excellent:
+            return NetworkQualityLevel::Excellent;
+        case livekit::ConnectionQuality::Lost:
+            return NetworkQualityLevel::Lost;
+        default:
+            return NetworkQualityLevel::Unknown;
+    }
+}
+
+bool hasNetworkStatsData(const NetworkStatsSnapshot& snapshot)
+{
+    return snapshot.rttMs >= 0
+        || snapshot.jitterMs >= 0
+        || snapshot.packetLossPercent >= 0.0
+        || snapshot.uplinkKbps >= 0
+        || snapshot.downlinkKbps >= 0
+        || snapshot.videoWidth > 0
+        || !snapshot.audioCodec.isEmpty()
+        || !snapshot.videoCodec.isEmpty()
+        || snapshot.availableSendBandwidthKbps >= 0
+        || !snapshot.transportProtocol.isEmpty();
+}

--- a/core/conference/network_stats_aggregator.h
+++ b/core/conference/network_stats_aggregator.h
@@ -1,0 +1,30 @@
+#ifndef CORE_CONFERENCE_NETWORK_STATS_AGGREGATOR_H
+#define CORE_CONFERENCE_NETWORK_STATS_AGGREGATOR_H
+
+#include <cstdint>
+#include <vector>
+#include "conference_types.h"
+#include "livekit/room_event_types.h"
+#include "livekit/stats.h"
+
+struct NetworkByteCounters {
+    std::uint64_t bytesSent{0};
+    std::uint64_t bytesReceived{0};
+    std::int64_t sampledAtMs{0};
+    bool valid{false};
+};
+
+struct NetworkStatsAggregationResult {
+    NetworkStatsSnapshot snapshot;
+    NetworkByteCounters counters;
+};
+
+NetworkStatsAggregationResult aggregateNetworkStats(
+    const std::vector<livekit::RtcStats>& stats,
+    const NetworkByteCounters& previousCounters,
+    std::int64_t nowMs);
+
+NetworkQualityLevel toNetworkQualityLevel(livekit::ConnectionQuality quality);
+bool hasNetworkStatsData(const NetworkStatsSnapshot& snapshot);
+
+#endif // CORE_CONFERENCE_NETWORK_STATS_AGGREGATOR_H

--- a/core/room_event_delegate.cpp
+++ b/core/room_event_delegate.cpp
@@ -1,5 +1,6 @@
 #include "room_event_delegate.h"
 #include "../utils/logger.h"
+#include "livekit/participant.h"
 #include "livekit/remote_participant.h"
 #include "livekit/remote_track_publication.h"
 #include "livekit/track.h"
@@ -121,6 +122,28 @@ void RoomEventDelegate::onTrackUnpublished(livekit::Room& room,
     
     emit trackUnpublishedQueued(trackSid, participantIdentity, kind, source);
 }
+
+void RoomEventDelegate::onConnectionQualityChanged(
+    livekit::Room& room,
+    const livekit::ConnectionQualityChangedEvent& event)
+{
+    Q_UNUSED(room);
+
+    if (!event.participant) {
+        return;
+    }
+
+    const QString participantIdentity =
+        QString::fromStdString(event.participant->identity());
+    const int quality = static_cast<int>(event.quality);
+
+    Logger::instance().info(QString("RoomEventDelegate: Connection quality changed for %1: %2")
+        .arg(participantIdentity)
+        .arg(quality));
+
+    emit connectionQualityChangedQueued(participantIdentity, quality);
+}
+
 void RoomEventDelegate::onConnectionStateChanged(livekit::Room& room, 
                                                   const livekit::ConnectionStateChangedEvent& event)
 {

--- a/core/room_event_delegate.h
+++ b/core/room_event_delegate.h
@@ -30,6 +30,8 @@ public:
                         const livekit::TrackUnmutedEvent& event) override;
     void onTrackUnpublished(livekit::Room& room,
                             const livekit::TrackUnpublishedEvent& event) override;
+    void onConnectionQualityChanged(livekit::Room& room,
+                                    const livekit::ConnectionQualityChangedEvent& event) override;
     void onConnectionStateChanged(livekit::Room& room, 
                                   const livekit::ConnectionStateChangedEvent& event) override;
     void onUserPacketReceived(livekit::Room& room, 
@@ -49,6 +51,7 @@ signals:
     void trackMutedQueued(QString trackSid, QString participantIdentity, int kind);
     void trackUnmutedQueued(QString trackSid, QString participantIdentity, int kind);
     void trackUnpublishedQueued(QString trackSid, QString participantIdentity, int kind, int source);
+    void connectionQualityChangedQueued(QString participantIdentity, int quality);
     void connectionStateChangedQueued(int state);
     void dataReceivedQueued(QByteArray data, QString participantIdentity, QString topic);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,6 +108,34 @@ target_include_directories(desktop_capture_tests PRIVATE
 )
 
 # =============================================================================
+# Conference network stats tests
+# =============================================================================
+
+add_executable(conference_network_stats_tests
+    core/test_network_stats_aggregator.cpp
+    ${CMAKE_SOURCE_DIR}/core/conference/network_stats_aggregator.cpp
+)
+
+set_target_properties(conference_network_stats_tests PROPERTIES
+    AUTOMOC OFF
+    AUTOUIC OFF
+    AUTORCC OFF
+)
+
+target_link_libraries(conference_network_stats_tests PRIVATE
+    GTest::gtest
+    GTest::gtest_main
+    Qt6::Core
+)
+
+target_include_directories(conference_network_stats_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/core
+    ${CMAKE_SOURCE_DIR}/utils
+    ${LIVEKIT_INCLUDE_DIR}
+)
+
+# =============================================================================
 # Cross-platform capture tests (macOS/Linux only)
 # =============================================================================
 
@@ -219,6 +247,7 @@ include(GoogleTest)
 gtest_discover_tests(audio_processing_tests DISCOVERY_MODE PRE_TEST)
 gtest_discover_tests(microphone_capturer_tests DISCOVERY_MODE PRE_TEST)
 gtest_discover_tests(desktop_capture_tests DISCOVERY_MODE PRE_TEST)
+gtest_discover_tests(conference_network_stats_tests DISCOVERY_MODE PRE_TEST)
 
 if(TARGET capture_platform_tests)
     gtest_discover_tests(capture_platform_tests DISCOVERY_MODE PRE_TEST)
@@ -262,4 +291,7 @@ if(WIN32)
 
     copy_runtime_if_exists(desktop_capture_tests "${GTEST_DLL_DIR}/gtest.dll")
     copy_runtime_if_exists(desktop_capture_tests "${GTEST_DLL_DIR}/gtest_main.dll")
+
+    copy_runtime_if_exists(conference_network_stats_tests "${GTEST_DLL_DIR}/gtest.dll")
+    copy_runtime_if_exists(conference_network_stats_tests "${GTEST_DLL_DIR}/gtest_main.dll")
 endif()

--- a/tests/core/test_network_stats_aggregator.cpp
+++ b/tests/core/test_network_stats_aggregator.cpp
@@ -1,0 +1,121 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "core/conference/network_stats_aggregator.h"
+
+namespace {
+
+livekit::RtcStats makeInboundStats(std::uint64_t packetsReceived,
+                                   std::int64_t packetsLost,
+                                   double jitterSeconds,
+                                   std::uint64_t bytesReceived)
+{
+    livekit::RtcInboundRtpStats inbound;
+    inbound.received.packets_received = packetsReceived;
+    inbound.received.packets_lost = packetsLost;
+    inbound.received.jitter = jitterSeconds;
+    inbound.inbound.bytes_received = bytesReceived;
+
+    livekit::RtcStats stats;
+    stats.stats = inbound;
+    return stats;
+}
+
+livekit::RtcStats makeOutboundStats(std::uint64_t bytesSent)
+{
+    livekit::RtcOutboundRtpStats outbound;
+    outbound.sent.bytes_sent = bytesSent;
+
+    livekit::RtcStats stats;
+    stats.stats = outbound;
+    return stats;
+}
+
+livekit::RtcStats makeRemoteInboundStats(double rttSeconds)
+{
+    livekit::RtcRemoteInboundRtpStats remoteInbound;
+    remoteInbound.remote_inbound.round_trip_time = rttSeconds;
+
+    livekit::RtcStats stats;
+    stats.stats = remoteInbound;
+    return stats;
+}
+
+livekit::RtcStats makeCandidatePairStats(double rttSeconds)
+{
+    livekit::RtcCandidatePairStats candidatePair;
+    candidatePair.candidate_pair.current_round_trip_time = rttSeconds;
+
+    livekit::RtcStats stats;
+    stats.stats = candidatePair;
+    return stats;
+}
+
+} // namespace
+
+TEST(NetworkStatsAggregatorTest, AggregatesRttJitterLossAndBitrate)
+{
+    const std::vector<livekit::RtcStats> firstSample{
+        makeInboundStats(190, 10, 0.015, 300000),
+        makeOutboundStats(200000),
+        makeRemoteInboundStats(0.050),
+    };
+
+    const NetworkByteCounters emptyCounters;
+    const auto firstResult = aggregateNetworkStats(firstSample, emptyCounters, 1000);
+
+    EXPECT_EQ(firstResult.snapshot.rttMs, 50);
+    EXPECT_EQ(firstResult.snapshot.jitterMs, 15);
+    EXPECT_NEAR(firstResult.snapshot.packetLossPercent, 5.0, 0.001);
+    EXPECT_EQ(firstResult.snapshot.uplinkKbps, -1);
+    EXPECT_EQ(firstResult.snapshot.downlinkKbps, -1);
+
+    const std::vector<livekit::RtcStats> secondSample{
+        makeInboundStats(380, 20, 0.014, 420000),
+        makeOutboundStats(260000),
+        makeRemoteInboundStats(0.055),
+    };
+    const auto secondResult =
+        aggregateNetworkStats(secondSample, firstResult.counters, 3000);
+
+    EXPECT_EQ(secondResult.snapshot.rttMs, 55);
+    EXPECT_EQ(secondResult.snapshot.jitterMs, 14);
+    EXPECT_NEAR(secondResult.snapshot.packetLossPercent, 5.0, 0.001);
+    EXPECT_EQ(secondResult.snapshot.uplinkKbps, 240);
+    EXPECT_EQ(secondResult.snapshot.downlinkKbps, 480);
+}
+
+TEST(NetworkStatsAggregatorTest, UsesCandidatePairRttWhenRemoteInboundMissing)
+{
+    const std::vector<livekit::RtcStats> sample{
+        makeInboundStats(100, 0, 0.010, 200000),
+        makeOutboundStats(100000),
+        makeCandidatePairStats(0.087),
+    };
+
+    const auto result = aggregateNetworkStats(sample, NetworkByteCounters{}, 1500);
+    EXPECT_EQ(result.snapshot.rttMs, 87);
+}
+
+TEST(NetworkStatsAggregatorTest, MapsConnectionQualityLevels)
+{
+    EXPECT_EQ(toNetworkQualityLevel(livekit::ConnectionQuality::Poor),
+              NetworkQualityLevel::Poor);
+    EXPECT_EQ(toNetworkQualityLevel(livekit::ConnectionQuality::Good),
+              NetworkQualityLevel::Good);
+    EXPECT_EQ(toNetworkQualityLevel(livekit::ConnectionQuality::Excellent),
+              NetworkQualityLevel::Excellent);
+    EXPECT_EQ(toNetworkQualityLevel(livekit::ConnectionQuality::Lost),
+              NetworkQualityLevel::Lost);
+}
+
+TEST(NetworkStatsAggregatorTest, DetectsMetricsAvailability)
+{
+    NetworkStatsSnapshot empty;
+    EXPECT_FALSE(hasNetworkStatsData(empty));
+
+    NetworkStatsSnapshot withRtt;
+    withRtt.rttMs = 35;
+    EXPECT_TRUE(hasNetworkStatsData(withRtt));
+}

--- a/tests/core/test_network_stats_aggregator.cpp
+++ b/tests/core/test_network_stats_aggregator.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <string>
 #include <vector>
 
 #include "core/conference/network_stats_aggregator.h"
@@ -46,6 +47,66 @@ livekit::RtcStats makeCandidatePairStats(double rttSeconds)
 {
     livekit::RtcCandidatePairStats candidatePair;
     candidatePair.candidate_pair.current_round_trip_time = rttSeconds;
+
+    livekit::RtcStats stats;
+    stats.stats = candidatePair;
+    return stats;
+}
+
+livekit::RtcStats makeVideoInboundStats(std::uint32_t width,
+                                        std::uint32_t height,
+                                        double fps)
+{
+    livekit::RtcInboundRtpStats inbound;
+    inbound.stream.kind = "video";
+    inbound.inbound.frame_width = width;
+    inbound.inbound.frame_height = height;
+    inbound.inbound.frames_per_second = fps;
+
+    livekit::RtcStats stats;
+    stats.stats = inbound;
+    return stats;
+}
+
+livekit::RtcStats makeVideoOutboundStats(std::uint32_t width,
+                                         std::uint32_t height,
+                                         double fps)
+{
+    livekit::RtcOutboundRtpStats outbound;
+    outbound.stream.kind = "video";
+    outbound.outbound.frame_width = width;
+    outbound.outbound.frame_height = height;
+    outbound.outbound.frames_per_second = fps;
+
+    livekit::RtcStats stats;
+    stats.stats = outbound;
+    return stats;
+}
+
+livekit::RtcStats makeCodecStats(const std::string& mimeType)
+{
+    livekit::RtcCodecStats codec;
+    codec.codec.mime_type = mimeType;
+
+    livekit::RtcStats stats;
+    stats.stats = codec;
+    return stats;
+}
+
+livekit::RtcStats makeLocalCandidateStats(const std::string& protocol)
+{
+    livekit::RtcLocalCandidateStats localCandidate;
+    localCandidate.candidate.protocol = protocol;
+
+    livekit::RtcStats stats;
+    stats.stats = localCandidate;
+    return stats;
+}
+
+livekit::RtcStats makeCandidatePairBitrateStats(double outgoingBitrateBps)
+{
+    livekit::RtcCandidatePairStats candidatePair;
+    candidatePair.candidate_pair.available_outgoing_bitrate = outgoingBitrateBps;
 
     livekit::RtcStats stats;
     stats.stats = candidatePair;
@@ -118,4 +179,28 @@ TEST(NetworkStatsAggregatorTest, DetectsMetricsAvailability)
     NetworkStatsSnapshot withRtt;
     withRtt.rttMs = 35;
     EXPECT_TRUE(hasNetworkStatsData(withRtt));
+}
+
+TEST(NetworkStatsAggregatorTest, AggregatesExtendedFieldsAndNormalizesProtocol)
+{
+    const std::vector<livekit::RtcStats> sample{
+        makeVideoInboundStats(640, 360, 30.0),
+        makeVideoOutboundStats(1920, 1080, 15.0),
+        makeVideoOutboundStats(1280, 720, 60.0),
+        makeCodecStats("audio/opus"),
+        makeCodecStats("video/H264"),
+        makeCandidatePairBitrateStats(789000.0),
+        makeLocalCandidateStats("udp"),
+    };
+
+    const auto result = aggregateNetworkStats(sample, NetworkByteCounters{}, 2000);
+
+    EXPECT_EQ(result.snapshot.videoWidth, 1920);
+    EXPECT_EQ(result.snapshot.videoHeight, 1080);
+    EXPECT_NEAR(result.snapshot.videoFps, 60.0, 0.001);
+    EXPECT_EQ(result.snapshot.audioCodec, "opus");
+    EXPECT_EQ(result.snapshot.videoCodec, "H264");
+    EXPECT_EQ(result.snapshot.availableSendBandwidthKbps, 789);
+    EXPECT_EQ(result.snapshot.transportProtocol, "UDP");
+    EXPECT_TRUE(hasNetworkStatsData(result.snapshot));
 }

--- a/ui/backend/ConferenceBackend.cpp
+++ b/ui/backend/ConferenceBackend.cpp
@@ -691,19 +691,6 @@ void ConferenceBackend::onConnected()
     connectionStatus_ = "Connected";
     connectionColor_ = "#4caf50";
     emit connectionStatusChanged();
-
-    bool networkChanged = false;
-    if (networkQuality_ != NetworkQualityLevel::Unknown) {
-        networkQuality_ = NetworkQualityLevel::Unknown;
-        networkChanged = true;
-    }
-    if (networkStatsDifferent(networkStats_, NetworkStatsSnapshot{})) {
-        networkStats_ = NetworkStatsSnapshot{};
-        networkChanged = true;
-    }
-    if (networkChanged) {
-        emit networkMetricsChanged();
-    }
     
     // Initialize local participant state
     micState_["local"] = conferenceManager_->isMicrophoneEnabled();
@@ -744,6 +731,7 @@ void ConferenceBackend::onDisconnected()
     participantReconcileTimer_.stop();
     meetingDurationTimer_.stop();
     meetingStartTime_ = QDateTime();  // invalidate
+    emit meetingDurationChanged();
     clearRemoteParticipantState();
     updateParticipantsList();
     emit participantCountChanged();

--- a/ui/backend/ConferenceBackend.cpp
+++ b/ui/backend/ConferenceBackend.cpp
@@ -9,6 +9,60 @@
 #include <QTimer>
 #include <QGuiApplication>
 #include <QScreen>
+#include <cmath>
+
+namespace {
+
+QString toQualityText(NetworkQualityLevel quality)
+{
+    switch (quality) {
+        case NetworkQualityLevel::Excellent:
+            return "优秀";
+        case NetworkQualityLevel::Good:
+            return "良好";
+        case NetworkQualityLevel::Poor:
+            return "较差";
+        case NetworkQualityLevel::Lost:
+            return "丢失";
+        default:
+            return "检测中";
+    }
+}
+
+QString toQualityColor(NetworkQualityLevel quality)
+{
+    switch (quality) {
+        case NetworkQualityLevel::Excellent:
+            return "#16A34A";
+        case NetworkQualityLevel::Good:
+            return "#059669";
+        case NetworkQualityLevel::Poor:
+            return "#D97706";
+        case NetworkQualityLevel::Lost:
+            return "#DC2626";
+        default:
+            return "#6B7280";
+    }
+}
+
+bool networkStatsDifferent(const NetworkStatsSnapshot& lhs,
+                           const NetworkStatsSnapshot& rhs)
+{
+    return lhs.rttMs != rhs.rttMs
+        || lhs.jitterMs != rhs.jitterMs
+        || std::fabs(lhs.packetLossPercent - rhs.packetLossPercent) >= 0.001
+        || lhs.uplinkKbps != rhs.uplinkKbps
+        || lhs.downlinkKbps != rhs.downlinkKbps
+        || lhs.videoWidth != rhs.videoWidth
+        || lhs.videoHeight != rhs.videoHeight
+        || std::fabs(lhs.videoFps - rhs.videoFps) >= 0.1
+        || lhs.audioCodec != rhs.audioCodec
+        || lhs.videoCodec != rhs.videoCodec
+        || lhs.availableSendBandwidthKbps != rhs.availableSendBandwidthKbps
+        || lhs.transportProtocol != rhs.transportProtocol;
+}
+
+} // namespace
 
 ConferenceBackend::ConferenceBackend(QObject* parent)
     : QObject(parent)
@@ -17,6 +71,12 @@ ConferenceBackend::ConferenceBackend(QObject* parent)
     , isHost_(false)
 {
     setupParticipantReconcileTimer();
+
+    meetingDurationTimer_.setInterval(1000);
+    meetingDurationTimer_.setSingleShot(false);
+    connect(&meetingDurationTimer_, &QTimer::timeout, this, [this]() {
+        emit meetingDurationChanged();
+    });
 }
 
 ConferenceBackend::~ConferenceBackend()
@@ -77,6 +137,23 @@ void ConferenceBackend::setupConnections()
             this, &ConferenceBackend::onTrackSubscribed);
     connect(conferenceManager_, &ConferenceManager::trackUnpublished,
             this, &ConferenceBackend::onTrackUnpublished);
+    connect(conferenceManager_, &ConferenceManager::localConnectionQualityChanged,
+            this, [this](int quality) {
+                const auto nextQuality = static_cast<NetworkQualityLevel>(quality);
+                if (nextQuality == networkQuality_) {
+                    return;
+                }
+                networkQuality_ = nextQuality;
+                emit networkMetricsChanged();
+            });
+    connect(conferenceManager_, &ConferenceManager::localNetworkStatsUpdated,
+            this, [this](const NetworkStatsSnapshot& stats) {
+                if (!networkStatsDifferent(networkStats_, stats)) {
+                    return;
+                }
+                networkStats_ = stats;
+                emit networkMetricsChanged();
+            });
     connect(conferenceManager_, &ConferenceManager::localScreenShareChanged,
             this, [this](bool enabled) {
                 emit screenSharingChanged();
@@ -178,6 +255,45 @@ int ConferenceBackend::participantCount() const
 bool ConferenceBackend::isConnected() const
 {
     return conferenceManager_ && conferenceManager_->isConnected();
+}
+
+QString ConferenceBackend::networkQualityText() const
+{
+    return toQualityText(networkQuality_);
+}
+
+QString ConferenceBackend::networkQualityColor() const
+{
+    return toQualityColor(networkQuality_);
+}
+
+bool ConferenceBackend::networkStatsAvailable() const
+{
+    return hasNetworkStatsData(networkStats_);
+}
+
+QString ConferenceBackend::videoResolution() const
+{
+    if (networkStats_.videoWidth > 0 && networkStats_.videoHeight > 0) {
+        return QString("%1x%2").arg(networkStats_.videoWidth).arg(networkStats_.videoHeight);
+    }
+    return QString();
+}
+
+QString ConferenceBackend::meetingDuration() const
+{
+    if (!meetingStartTime_.isValid()) {
+        return QStringLiteral("00:00:00");
+    }
+    qint64 elapsed = meetingStartTime_.secsTo(QDateTime::currentDateTime());
+    if (elapsed < 0) elapsed = 0;
+    int h = static_cast<int>(elapsed / 3600);
+    int m = static_cast<int>((elapsed % 3600) / 60);
+    int s = static_cast<int>(elapsed % 60);
+    return QString("%1:%2:%3")
+        .arg(h, 2, 10, QChar('0'))
+        .arg(m, 2, 10, QChar('0'))
+        .arg(s, 2, 10, QChar('0'));
 }
 
 bool ConferenceBackend::micEnabled() const
@@ -575,6 +691,19 @@ void ConferenceBackend::onConnected()
     connectionStatus_ = "Connected";
     connectionColor_ = "#4caf50";
     emit connectionStatusChanged();
+
+    bool networkChanged = false;
+    if (networkQuality_ != NetworkQualityLevel::Unknown) {
+        networkQuality_ = NetworkQualityLevel::Unknown;
+        networkChanged = true;
+    }
+    if (networkStatsDifferent(networkStats_, NetworkStatsSnapshot{})) {
+        networkStats_ = NetworkStatsSnapshot{};
+        networkChanged = true;
+    }
+    if (networkChanged) {
+        emit networkMetricsChanged();
+    }
     
     // Initialize local participant state
     micState_["local"] = conferenceManager_->isMicrophoneEnabled();
@@ -585,6 +714,11 @@ void ConferenceBackend::onConnected()
         participantReconcileTimer_.start();
     }
     reconcileParticipantsNow("connected");
+
+    // Start meeting duration tracking
+    meetingStartTime_ = QDateTime::currentDateTime();
+    meetingDurationTimer_.start();
+    emit meetingDurationChanged();
 }
 
 void ConferenceBackend::onDisconnected()
@@ -594,7 +728,22 @@ void ConferenceBackend::onDisconnected()
     connectionColor_ = "#ff5252";
     emit connectionStatusChanged();
 
+    bool networkChanged = false;
+    if (networkQuality_ != NetworkQualityLevel::Unknown) {
+        networkQuality_ = NetworkQualityLevel::Unknown;
+        networkChanged = true;
+    }
+    if (networkStatsDifferent(networkStats_, NetworkStatsSnapshot{})) {
+        networkStats_ = NetworkStatsSnapshot{};
+        networkChanged = true;
+    }
+    if (networkChanged) {
+        emit networkMetricsChanged();
+    }
+
     participantReconcileTimer_.stop();
+    meetingDurationTimer_.stop();
+    meetingStartTime_ = QDateTime();  // invalidate
     clearRemoteParticipantState();
     updateParticipantsList();
     emit participantCountChanged();
@@ -614,6 +763,12 @@ void ConferenceBackend::onConnectionStateChanged(livekit::ConnectionState state)
         case livekit::ConnectionState::Reconnecting:
             connectionStatus_ = "Reconnecting...";
             connectionColor_ = "#ff9800";
+            if (networkQuality_ != NetworkQualityLevel::Unknown
+                || networkStatsDifferent(networkStats_, NetworkStatsSnapshot{})) {
+                networkQuality_ = NetworkQualityLevel::Unknown;
+                networkStats_ = NetworkStatsSnapshot{};
+                emit networkMetricsChanged();
+            }
             break;
         default:
             connectionStatus_ = "Unknown";

--- a/ui/backend/ConferenceBackend.h
+++ b/ui/backend/ConferenceBackend.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QTimer>
+#include <QDateTime>
 #include <QVariant>
 #include <QVariantList>
 #include <QImage>
@@ -25,6 +26,21 @@ class ConferenceBackend : public QObject
     Q_PROPERTY(QString connectionStatus READ connectionStatus NOTIFY connectionStatusChanged)
     Q_PROPERTY(QString connectionColor READ connectionColor NOTIFY connectionStatusChanged)
     Q_PROPERTY(bool isConnected READ isConnected NOTIFY connectionStatusChanged)
+    Q_PROPERTY(QString networkQualityText READ networkQualityText NOTIFY networkMetricsChanged)
+    Q_PROPERTY(QString networkQualityColor READ networkQualityColor NOTIFY networkMetricsChanged)
+    Q_PROPERTY(int networkRttMs READ networkRttMs NOTIFY networkMetricsChanged)
+    Q_PROPERTY(int networkJitterMs READ networkJitterMs NOTIFY networkMetricsChanged)
+    Q_PROPERTY(double networkPacketLossPercent READ networkPacketLossPercent NOTIFY networkMetricsChanged)
+    Q_PROPERTY(int networkUplinkKbps READ networkUplinkKbps NOTIFY networkMetricsChanged)
+    Q_PROPERTY(int networkDownlinkKbps READ networkDownlinkKbps NOTIFY networkMetricsChanged)
+    Q_PROPERTY(bool networkStatsAvailable READ networkStatsAvailable NOTIFY networkMetricsChanged)
+    Q_PROPERTY(QString videoResolution READ videoResolution NOTIFY networkMetricsChanged)
+    Q_PROPERTY(double videoFps READ videoFps NOTIFY networkMetricsChanged)
+    Q_PROPERTY(QString audioCodec READ audioCodec NOTIFY networkMetricsChanged)
+    Q_PROPERTY(QString videoCodec READ videoCodec NOTIFY networkMetricsChanged)
+    Q_PROPERTY(int availableSendBandwidth READ availableSendBandwidth NOTIFY networkMetricsChanged)
+    Q_PROPERTY(QString transportProtocol READ transportProtocol NOTIFY networkMetricsChanged)
+    Q_PROPERTY(QString meetingDuration READ meetingDuration NOTIFY meetingDurationChanged)
 
     Q_PROPERTY(bool micEnabled READ micEnabled NOTIFY micEnabledChanged)
     Q_PROPERTY(bool camEnabled READ camEnabled NOTIFY camEnabledChanged)
@@ -65,6 +81,21 @@ public:
     QString connectionStatus() const { return connectionStatus_; }
     QString connectionColor() const { return connectionColor_; }
     bool isConnected() const;
+    QString networkQualityText() const;
+    QString networkQualityColor() const;
+    int networkRttMs() const { return networkStats_.rttMs; }
+    int networkJitterMs() const { return networkStats_.jitterMs; }
+    double networkPacketLossPercent() const { return networkStats_.packetLossPercent; }
+    int networkUplinkKbps() const { return networkStats_.uplinkKbps; }
+    int networkDownlinkKbps() const { return networkStats_.downlinkKbps; }
+    bool networkStatsAvailable() const;
+    QString videoResolution() const;
+    double videoFps() const { return networkStats_.videoFps; }
+    QString audioCodec() const { return networkStats_.audioCodec; }
+    QString videoCodec() const { return networkStats_.videoCodec; }
+    int availableSendBandwidth() const { return networkStats_.availableSendBandwidthKbps; }
+    QString transportProtocol() const { return networkStats_.transportProtocol; }
+    QString meetingDuration() const;
     bool micEnabled() const;
     bool camEnabled() const;
     bool screenSharing() const;
@@ -127,6 +158,8 @@ signals:
     void userNameChanged();
     void participantCountChanged();
     void connectionStatusChanged();
+    void networkMetricsChanged();
+    void meetingDurationChanged();
     void micEnabledChanged();
     void camEnabledChanged();
     void screenSharingChanged();
@@ -196,6 +229,8 @@ private:
 
     QString connectionStatus_{"Connecting..."};
     QString connectionColor_{"#a0a0b0"};
+    NetworkQualityLevel networkQuality_{NetworkQualityLevel::Unknown};
+    NetworkStatsSnapshot networkStats_;
 
     bool isChatVisible_{false};
     bool isParticipantsVisible_{false};
@@ -220,6 +255,8 @@ private:
 
     QMap<QString, QPair<QString, bool>> trackInfoMap_;
     QTimer participantReconcileTimer_;
+    QTimer meetingDurationTimer_;
+    QDateTime meetingStartTime_;
 };
 
 #endif // CONFERENCE_BACKEND_H

--- a/ui/qml/conference/ConferenceTitleBar.qml
+++ b/ui/qml/conference/ConferenceTitleBar.qml
@@ -19,6 +19,22 @@ Rectangle {
     property point dragStartPos
     property bool dragging: false
 
+    function formatLatency(value) {
+        return value >= 0 ? value + " ms" : "--"
+    }
+
+    function formatBitrate(value) {
+        return value >= 0 ? value + " kbps" : "--"
+    }
+
+    function formatPacketLoss(value) {
+        return value >= 0 ? Number(value).toFixed(1) + "%" : "--"
+    }
+
+    function formatFps(value) {
+        return value >= 0 ? Number(value).toFixed(1) + " FPS" : "--"
+    }
+
     MouseArea {
         anchors.fill: parent
 
@@ -378,25 +394,149 @@ Rectangle {
             spacing: 16
             Layout.alignment: Qt.AlignVCenter
 
-            // Network Status (Mock)
             Rectangle {
+                id: networkStatusPill
+
+                property color qualityColor: backend ? backend.networkQualityColor : "#6B7280"
+
                 height: 24
-                width: 80
+                width: Math.max(96, networkStatusLabelMetrics.width + 30)
                 radius: 12
-                color: "#ECFDF5" // Emerald-50
+                color: Qt.rgba(qualityColor.r, qualityColor.g, qualityColor.b, 0.12)
+                border.color: Qt.rgba(qualityColor.r, qualityColor.g, qualityColor.b, 0.32)
+                border.width: 1
 
                 RowLayout {
                     anchors.centerIn: parent
                     spacing: 4
+
                     Rectangle {
-                        width: 6; height: 6; radius: 3
-                        color: "#10B981" // Emerald-500
+                        width: 6
+                        height: 6
+                        radius: 3
+                        color: networkStatusPill.qualityColor
                     }
+
                     Text {
-                        text: "连接稳定"
-                        color: "#059669" // Emerald-600
+                        id: networkStatusLabel
+                        text: backend ? (backend.networkQualityText + " · "
+                                         + (backend.networkRttMs >= 0 ? backend.networkRttMs + "ms" : "--ms"))
+                                      : "检测中 · --ms"
+                        color: networkStatusPill.qualityColor
                         font.pixelSize: 11
                         font.weight: Font.Medium
+                    }
+                }
+
+                TextMetrics {
+                    id: networkStatusLabelMetrics
+                    text: networkStatusLabel.text
+                    font: networkStatusLabel.font
+                }
+
+                MouseArea {
+                    id: networkStatusArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: {
+                        if (networkStatsPopup.visible)
+                            networkStatsPopup.close()
+                        else
+                            networkStatsPopup.open()
+                    }
+                }
+
+                ToolTip.visible: networkStatusArea.containsMouse && !networkStatsPopup.visible
+                ToolTip.text: "网络详情"
+                ToolTip.delay: 500
+
+                Popup {
+                    id: networkStatsPopup
+                    y: networkStatusPill.height + 8
+                    x: Math.round((networkStatusPill.width - width) / 2)
+                    width: 480
+                    padding: 0
+                    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
+
+                    background: Rectangle {
+                        color: "#FFFFFF"
+                        radius: 12
+                        border.color: "#E5E7EB"
+                        border.width: 1
+                    }
+
+                    contentItem: RowLayout {
+                        spacing: 0
+
+                        // --- Left Column: Connection & Network ---
+                        GridLayout {
+                            columns: 2
+                            rowSpacing: 8
+                            columnSpacing: 12
+                            Layout.fillWidth: true
+                            Layout.margins: 14
+
+                            Text { text: "连接状态"; color: "#6B7280"; font.pixelSize: 11 }
+                            Text { text: backend ? backend.connectionStatus : "--"; color: "#111827"; font.pixelSize: 11; font.weight: Font.Medium }
+
+                            Text { text: "连接质量"; color: "#6B7280"; font.pixelSize: 11 }
+                            Text { text: backend ? backend.networkQualityText : "检测中"; color: backend ? backend.networkQualityColor : "#6B7280"; font.pixelSize: 11; font.weight: Font.Medium }
+
+                            Text { text: "会议时长"; color: "#6B7280"; font.pixelSize: 11 }
+                            Text { text: backend ? backend.meetingDuration : "00:00:00"; color: "#111827"; font.pixelSize: 11; font.weight: Font.Medium }
+
+                            Rectangle { Layout.columnSpan: 2; Layout.fillWidth: true; height: 1; color: "#F3F4F6" }
+
+                            Text { text: "延迟 RTT"; color: "#6B7280"; font.pixelSize: 11 }
+                            Text { text: root.formatLatency(backend ? backend.networkRttMs : -1); color: "#111827"; font.pixelSize: 11; font.weight: Font.Medium }
+
+                            Text { text: "抖动"; color: "#6B7280"; font.pixelSize: 11 }
+                            Text { text: root.formatLatency(backend ? backend.networkJitterMs : -1); color: "#111827"; font.pixelSize: 11; font.weight: Font.Medium }
+
+                            Text { text: "丢包率"; color: "#6B7280"; font.pixelSize: 11 }
+                            Text { text: root.formatPacketLoss(backend ? backend.networkPacketLossPercent : -1); color: "#111827"; font.pixelSize: 11; font.weight: Font.Medium }
+
+                            Text { text: "上行码率"; color: "#6B7280"; font.pixelSize: 11 }
+                            Text { text: root.formatBitrate(backend ? backend.networkUplinkKbps : -1); color: "#111827"; font.pixelSize: 11; font.weight: Font.Medium }
+
+                            Text { text: "下行码率"; color: "#6B7280"; font.pixelSize: 11 }
+                            Text { text: root.formatBitrate(backend ? backend.networkDownlinkKbps : -1); color: "#111827"; font.pixelSize: 11; font.weight: Font.Medium }
+                        }
+
+                        // --- Vertical Divider ---
+                        Rectangle { width: 1; Layout.fillHeight: true; Layout.topMargin: 10; Layout.bottomMargin: 10; color: "#F3F4F6" }
+
+                        // --- Right Column: Media & Codec ---
+                        GridLayout {
+                            columns: 2
+                            rowSpacing: 8
+                            columnSpacing: 12
+                            Layout.fillWidth: true
+                            Layout.margins: 14
+
+                            Text { text: "传输协议"; color: "#6B7280"; font.pixelSize: 11 }
+                            Text { text: (backend && backend.transportProtocol.length > 0) ? backend.transportProtocol : "--"; color: "#111827"; font.pixelSize: 11; font.weight: Font.Medium }
+
+                            Text { text: "可用带宽"; color: "#6B7280"; font.pixelSize: 11 }
+                            Text { text: root.formatBitrate(backend ? backend.availableSendBandwidth : -1); color: "#111827"; font.pixelSize: 11; font.weight: Font.Medium }
+
+                            Rectangle { Layout.columnSpan: 2; Layout.fillWidth: true; height: 1; color: "#F3F4F6" }
+
+                            Text { text: "音频编码"; color: "#6B7280"; font.pixelSize: 11 }
+                            Text { text: (backend && backend.audioCodec.length > 0) ? backend.audioCodec : "--"; color: "#111827"; font.pixelSize: 11; font.weight: Font.Medium }
+
+                            Text { text: "视频编码"; color: "#6B7280"; font.pixelSize: 11 }
+                            Text { text: (backend && backend.videoCodec.length > 0) ? backend.videoCodec : "--"; color: "#111827"; font.pixelSize: 11; font.weight: Font.Medium }
+
+                            Rectangle { Layout.columnSpan: 2; Layout.fillWidth: true; height: 1; color: "#F3F4F6" }
+
+                            Text { text: "视频分辨率"; color: "#6B7280"; font.pixelSize: 11 }
+                            Text { text: (backend && backend.videoResolution.length > 0) ? backend.videoResolution : "--"; color: "#111827"; font.pixelSize: 11; font.weight: Font.Medium }
+
+                            Text { text: "视频帧率"; color: "#6B7280"; font.pixelSize: 11 }
+                            Text { text: root.formatFps(backend ? backend.videoFps : -1); color: "#111827"; font.pixelSize: 11; font.weight: Font.Medium }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This pull request introduces comprehensive support for real-time network quality and statistics tracking in the conference management module. The main changes involve new data structures and logic to aggregate, estimate, and emit network statistics, as well as the integration of these features into the conference lifecycle.

**Network statistics and quality tracking:**

* Added the `NetworkStatsSnapshot` struct and `NetworkQualityLevel` enum to `conference_types.h` for representing network metrics and quality levels, with corresponding Qt metatype registration for signal/slot usage. [[1]](diffhunk://#diff-1375e12eea2b4c2e06608c30e45ba323f64a6b1c7344b84cfb4242948ba600deR28-R53) [[2]](diffhunk://#diff-1375e12eea2b4c2e06608c30e45ba323f64a6b1c7344b84cfb4242948ba600deR63-R64)
* Introduced a `network_stats_aggregator` module and integrated it into the build system (`CMakeLists.txt`) and `conference_manager` for aggregating RTC stats into user-facing network metrics. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR57) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR114) [[3]](diffhunk://#diff-c802c3d9c4c87078f431d242701ba68670941a95947a912a5f918ae32346b307R10-R12)

**Conference manager enhancements:**

* Implemented periodic polling of local network stats via a `QTimer`, collecting and aggregating track-level stats, with logic to handle missing or estimated data and emit updates through new signals (`localConnectionQualityChanged`, `localNetworkStatsUpdated`). [[1]](diffhunk://#diff-c802c3d9c4c87078f431d242701ba68670941a95947a912a5f918ae32346b307R115-R116) [[2]](diffhunk://#diff-c802c3d9c4c87078f431d242701ba68670941a95947a912a5f918ae32346b307R152-R156) [[3]](diffhunk://#diff-d9f3e36a97851507ae21d5ef07e030727a2cd331947b09270c355afd041ae5d0R100-R104) [[4]](diffhunk://#diff-d9f3e36a97851507ae21d5ef07e030727a2cd331947b09270c355afd041ae5d0R732-R909)
* Added logic to respond to connection quality change events, updating local state and emitting signals as needed, including fallback to estimated stats when real data is unavailable. [[1]](diffhunk://#diff-d9f3e36a97851507ae21d5ef07e030727a2cd331947b09270c355afd041ae5d0R71-R72) [[2]](diffhunk://#diff-d9f3e36a97851507ae21d5ef07e030727a2cd331947b09270c355afd041ae5d0R524-R559)
* Managed network stats state transitions on connect, disconnect, and reconnect, ensuring stats are reset and signals are emitted appropriately during lifecycle changes. [[1]](diffhunk://#diff-d9f3e36a97851507ae21d5ef07e030727a2cd331947b09270c355afd041ae5d0R166-R170) [[2]](diffhunk://#diff-d9f3e36a97851507ae21d5ef07e030727a2cd331947b09270c355afd041ae5d0R578-R596)

**Internal utilities and refactoring:**

* Added helper methods for comparing network stats, collecting relevant tracks, building estimated snapshots, and resetting metrics, encapsulating the new logic cleanly within `ConferenceManager`. [[1]](diffhunk://#diff-d9f3e36a97851507ae21d5ef07e030727a2cd331947b09270c355afd041ae5d0R12-R41) [[2]](diffhunk://#diff-c802c3d9c4c87078f431d242701ba68670941a95947a912a5f918ae32346b307R130-R140) [[3]](diffhunk://#diff-d9f3e36a97851507ae21d5ef07e030727a2cd331947b09270c355afd041ae5d0R732-R909)

These updates lay the groundwork for improved user feedback and diagnostics regarding network conditions during conferences.