### PR TITLE
feat(conference): auto-hide top and bottom bars on inactivity

### DIFF
--- a/ui/qml/conference/ConferenceWindow.qml
+++ b/ui/qml/conference/ConferenceWindow.qml
@@ -25,6 +25,14 @@ Window {
     property string userAuthToken: ""
     property bool isHost: false
     property bool isGuest: false
+    property bool chromeAutoHideEnabled: true
+    property bool topChromeVisible: true
+    property bool bottomChromeVisible: true
+    property int chromeAutoHideDelayMs: 3000
+    property int topRevealZoneHeight: 48
+    property int bottomRevealZoneHeight: 72
+    property int topChromeHeight: 52
+    property int bottomChromeHeight: 68
 
     // Backend
     ConferenceBackend {
@@ -241,6 +249,75 @@ Window {
         }
     }
 
+    function restartChromeAutoHideTimer() {
+        if (!chromeAutoHideEnabled || !visible) {
+            return
+        }
+        chromeAutoHideTimer.restart()
+    }
+
+    function resetChromeVisibility() {
+        topChromeVisible = true
+        bottomChromeVisible = true
+        restartChromeAutoHideTimer()
+    }
+
+    function maybeRevealChromeByPointer(pointerY) {
+        if (!chromeAutoHideEnabled || !visible) {
+            return
+        }
+
+        var nearTop = pointerY <= topRevealZoneHeight
+        var nearBottom = pointerY >= (windowFrame.height - bottomRevealZoneHeight)
+        var didReveal = false
+
+        if (!topChromeVisible && nearTop) {
+            topChromeVisible = true
+            didReveal = true
+        }
+        if (!bottomChromeVisible && nearBottom) {
+            bottomChromeVisible = true
+            didReveal = true
+        }
+
+        if (didReveal || topChromeVisible || bottomChromeVisible) {
+            restartChromeAutoHideTimer()
+        }
+    }
+
+    Timer {
+        id: chromeAutoHideTimer
+        interval: root.chromeAutoHideDelayMs
+        repeat: false
+        running: false
+
+        onTriggered: {
+            if (!root.chromeAutoHideEnabled || !root.visible) {
+                return
+            }
+            root.topChromeVisible = false
+            root.bottomChromeVisible = false
+        }
+    }
+
+    Component.onCompleted: resetChromeVisibility()
+
+    onActiveChanged: {
+        if (active) {
+            resetChromeVisibility()
+        } else {
+            chromeAutoHideTimer.stop()
+        }
+    }
+
+    onVisibleChanged: {
+        if (visible) {
+            resetChromeVisibility()
+        } else {
+            chromeAutoHideTimer.stop()
+        }
+    }
+
     // Main content
     Rectangle {
         id: windowFrame
@@ -258,16 +335,32 @@ Window {
             spacing: 0
 
             // Title bar
-            ConferenceTitleBar {
-                id: titleBar
+            Item {
+                id: topBarHost
                 Layout.fillWidth: true
-                targetWindow: root
-                backend: backend
-                shareUrl: {
-                    if (!backend.meetingNo || backend.meetingNo.length === 0)
-                        return ""
-                    var base = settingsBackendInstance.apiUrl.replace(/\/+$/, "")
-                    return base + "/join?meetingNo=" + encodeURIComponent(backend.meetingNo)
+                Layout.preferredHeight: root.topChromeVisible ? root.topChromeHeight : 0
+                opacity: root.topChromeVisible ? 1 : 0
+                visible: Layout.preferredHeight > 0 || opacity > 0
+                clip: true
+
+                Behavior on Layout.preferredHeight {
+                    NumberAnimation { duration: 220; easing.type: Easing.OutCubic }
+                }
+                Behavior on opacity {
+                    NumberAnimation { duration: 160; easing.type: Easing.OutQuad }
+                }
+
+                ConferenceTitleBar {
+                    id: titleBar
+                    anchors.fill: parent
+                    targetWindow: root
+                    backend: backend
+                    shareUrl: {
+                        if (!backend.meetingNo || backend.meetingNo.length === 0)
+                            return ""
+                        var base = settingsBackendInstance.apiUrl.replace(/\/+$/, "")
+                        return base + "/join?meetingNo=" + encodeURIComponent(backend.meetingNo)
+                    }
                 }
             }
 
@@ -683,17 +776,98 @@ Window {
             }
 
             // Fixed bottom control bar
-            ControlBar {
-                id: controlBar
+            Item {
+                id: bottomBarHost
                 Layout.fillWidth: true
-                backend: backend
-                settingsBackend: settingsBackendInstance
-                isGuest: root.isGuest
+                Layout.preferredHeight: root.bottomChromeVisible ? root.bottomChromeHeight : 0
+                opacity: root.bottomChromeVisible ? 1 : 0
+                visible: Layout.preferredHeight > 0 || opacity > 0
+                clip: true
 
-                onScreenShareClicked: {
-                    if (backend && backend.screenShareSupported) {
-                        screenPickerDialog.open()
+                Behavior on Layout.preferredHeight {
+                    NumberAnimation { duration: 220; easing.type: Easing.OutCubic }
+                }
+                Behavior on opacity {
+                    NumberAnimation { duration: 160; easing.type: Easing.OutQuad }
+                }
+
+                ControlBar {
+                    id: controlBar
+                    anchors.fill: parent
+                    backend: backend
+                    settingsBackend: settingsBackendInstance
+                    isGuest: root.isGuest
+
+                    onScreenShareClicked: {
+                        if (backend && backend.screenShareSupported) {
+                            screenPickerDialog.open()
+                        }
                     }
+                }
+            }
+        }
+
+        HoverHandler {
+            id: activityHoverHandler
+
+            onPointChanged: function(point) {
+                if (!point) {
+                    return
+                }
+                var yInWindowFrame = point.position.y
+                if (point.scenePosition) {
+                    yInWindowFrame = point.scenePosition.y - windowFrame.y
+                }
+                root.maybeRevealChromeByPointer(yInWindowFrame)
+            }
+        }
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            height: root.topRevealZoneHeight
+            visible: root.chromeAutoHideEnabled && !root.topChromeVisible
+            color: "transparent"
+            z: 40
+
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons: Qt.NoButton
+                hoverEnabled: true
+
+                onEntered: {
+                    root.topChromeVisible = true
+                    root.restartChromeAutoHideTimer()
+                }
+
+                onPositionChanged: function(mouse) {
+                    root.maybeRevealChromeByPointer(mouse.y)
+                }
+            }
+        }
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            height: root.bottomRevealZoneHeight
+            visible: root.chromeAutoHideEnabled && !root.bottomChromeVisible
+            color: "transparent"
+            z: 40
+
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons: Qt.NoButton
+                hoverEnabled: true
+
+                onEntered: {
+                    root.bottomChromeVisible = true
+                    root.restartChromeAutoHideTimer()
+                }
+
+                onPositionChanged: function(mouse) {
+                    root.maybeRevealChromeByPointer(parent.y + mouse.y)
                 }
             }
         }
@@ -719,9 +893,9 @@ Window {
             id: rightSidebarHost
             anchors.right: parent.right
             anchors.top: parent.top
-            anchors.topMargin: 52
+            anchors.topMargin: topBarHost.height
             anchors.bottom: parent.bottom
-            anchors.bottomMargin: 68
+            anchors.bottomMargin: bottomBarHost.height
             width: (backend.isChatVisible || backend.isParticipantsVisible) ? 320 : 0
             opacity: (backend.isChatVisible || backend.isParticipantsVisible) ? 1 : 0
             visible: width > 0 || backend.isChatVisible || backend.isParticipantsVisible


### PR DESCRIPTION
This pull request introduces a new auto-hide feature for the top and bottom chrome (UI bars) in the `ConferenceWindow.qml`, making the interface cleaner and more immersive by hiding the controls when not in use and revealing them on user activity. The implementation includes new properties, behaviors, and event handlers to manage the chrome's visibility based on user interaction such as mouse movement and hover events.

Key changes:

**Auto-hide chrome feature:**

* Added properties to control chrome auto-hide behavior, including enable/disable flag, visibility states, delay, and reveal zone sizes (`chromeAutoHideEnabled`, `topChromeVisible`, `bottomChromeVisible`, `chromeAutoHideDelayMs`, etc.).
* Implemented functions (`restartChromeAutoHideTimer`, `resetChromeVisibility`, `maybeRevealChromeByPointer`) and a `Timer` to manage the visibility and auto-hide timing of the chrome bars.

**UI structure and animation:**

* Refactored the top and bottom chrome into `Item` containers (`topBarHost`, `bottomBarHost`) with animated height and opacity transitions for smooth showing/hiding, and updated their layout logic. [[1]](diffhunk://#diff-77cb25a665d8ebc46f09bdb49d1b42ec3c0e51a47840b6d5857c417a81a5410fR338-R355) [[2]](diffhunk://#diff-77cb25a665d8ebc46f09bdb49d1b42ec3c0e51a47840b6d5857c417a81a5410fR779-R796)
* Updated the sidebar anchors to use the dynamic heights of the chrome bars for proper layout when chrome visibility changes.

**User interaction handling:**

* Added invisible hover zones at the top and bottom of the window using `Rectangle` and `MouseArea` to detect pointer proximity and reveal the chrome when the user moves the mouse near the edges.
* Integrated a `HoverHandler` to track pointer movement and trigger chrome reveal logic when appropriate.