### PR TITLE
feat(ci): add cross-platform installer packaging

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -184,7 +184,7 @@ jobs:
           if-no-files-found: error
 
   package-macos:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: resolve-version
     env:
       LINKS_SDK_ARCH: arm64
@@ -197,7 +197,7 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           version: ${{ env.QT_VERSION }}
-          arch: clang_64
+          arch: clang_arm64
           modules: qtmultimedia
           cache: true
 
@@ -246,6 +246,13 @@ jobs:
             exit 1
           fi
 
+          binary_arch="$(file "$binary_path")"
+          echo "$binary_arch"
+          if [[ "$binary_arch" != *"arm64"* ]]; then
+            echo "Expected arm64 app binary, got: $binary_arch" >&2
+            exit 1
+          fi
+
           mkdir -p "$frameworks_dir" "$dist_dir"
 
           livekit_lib="$(find "$GITHUB_WORKSPACE/third_party" -name liblivekit.dylib -print -quit)"
@@ -258,6 +265,18 @@ jobs:
               exit 1
             fi
             cp -f "$lib" "$frameworks_dir/"
+          done
+
+          for copied_lib in \
+            "$frameworks_dir/liblivekit.dylib" \
+            "$frameworks_dir/liblivekit_ffi.dylib" \
+            "$frameworks_dir/libwebrtc-audio-processing-2.1.dylib"; do
+            lib_arch="$(file "$copied_lib")"
+            echo "$lib_arch"
+            if [[ "$lib_arch" != *"arm64"* ]]; then
+              echo "Expected arm64 dylib, got: $lib_arch" >&2
+              exit 1
+            fi
           done
 
           install_name_tool -add_rpath "@executable_path/../Frameworks" "$binary_path" 2>/dev/null || true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -346,7 +346,6 @@ jobs:
           sudo apt-get install -y \
             ninja-build \
             patchelf \
-            wget \
             file \
             libgl1-mesa-dev \
             libxkbcommon-dev \
@@ -417,18 +416,67 @@ jobs:
 
           patchelf --set-rpath '$ORIGIN/../lib' "$appdir/usr/bin/links"
 
-          linuxdeploy_version="1-alpha-20250213-2"
-          linuxdeploy_plugin_qt_version="1-alpha-20250213-2"
-          linuxdeploy_sha256="<REPLACE_WITH_LINUXDEPLOY_SHA256>"
-          linuxdeploy_plugin_qt_sha256="<REPLACE_WITH_LINUXDEPLOY_PLUGIN_QT_SHA256>"
+          export linuxdeploy_version="1-alpha-20250213-2"
+          export linuxdeploy_plugin_qt_version="1-alpha-20250213-1"
 
-          curl -fsSLo linuxdeploy-x86_64.AppImage \
-            "https://github.com/linuxdeploy/linuxdeploy/releases/download/${linuxdeploy_version}/linuxdeploy-x86_64.AppImage"
-          curl -fsSLo linuxdeploy-plugin-qt-x86_64.AppImage \
-            "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/${linuxdeploy_plugin_qt_version}/linuxdeploy-plugin-qt-x86_64.AppImage"
+          python3 <<'PY'
+          import hashlib
+          import json
+          import os
+          import sys
+          import urllib.request
 
-          printf '%s  %s\n' "$linuxdeploy_sha256" "linuxdeploy-x86_64.AppImage" | sha256sum -c -
-          printf '%s  %s\n' "$linuxdeploy_plugin_qt_sha256" "linuxdeploy-plugin-qt-x86_64.AppImage" | sha256sum -c -
+          ASSETS = [
+              (
+                  "linuxdeploy/linuxdeploy",
+                  os.environ["linuxdeploy_version"],
+                  "linuxdeploy-x86_64.AppImage",
+              ),
+              (
+                  "linuxdeploy/linuxdeploy-plugin-qt",
+                  os.environ["linuxdeploy_plugin_qt_version"],
+                  "linuxdeploy-plugin-qt-x86_64.AppImage",
+              ),
+          ]
+
+          def request(url):
+              headers = {
+                  "Accept": "application/vnd.github+json",
+                  "User-Agent": "links-package-workflow",
+              }
+              token = os.environ.get("GITHUB_TOKEN")
+              if token:
+                  headers["Authorization"] = f"Bearer {token}"
+              return urllib.request.Request(url, headers=headers)
+
+          for repo, tag, asset_name in ASSETS:
+              api_url = f"https://api.github.com/repos/{repo}/releases/tags/{tag}"
+              with urllib.request.urlopen(request(api_url)) as response:
+                  release = json.load(response)
+
+              asset = next((item for item in release.get("assets", []) if item.get("name") == asset_name), None)
+              if asset is None:
+                  print(f"Release asset not found: {repo}@{tag}/{asset_name}", file=sys.stderr)
+                  sys.exit(1)
+
+              digest = asset.get("digest") or ""
+              if not digest.startswith("sha256:"):
+                  print(f"Release asset has no sha256 digest: {repo}@{tag}/{asset_name}", file=sys.stderr)
+                  sys.exit(1)
+
+              url = asset["browser_download_url"]
+              with urllib.request.urlopen(request(url)) as response, open(asset_name, "wb") as output:
+                  data = response.read()
+                  output.write(data)
+
+              actual = hashlib.sha256(data).hexdigest()
+              expected = digest.removeprefix("sha256:")
+              if actual.lower() != expected.lower():
+                  print(f"SHA256 mismatch for {asset_name}: expected {expected}, got {actual}", file=sys.stderr)
+                  sys.exit(1)
+
+              print(f"Downloaded and verified {asset_name}: sha256:{actual}")
+          PY
 
           chmod +x linuxdeploy-x86_64.AppImage linuxdeploy-plugin-qt-x86_64.AppImage
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,446 @@
+name: Package
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version without v. Defaults to 0.0.0-dev.<run_number>."
+        required: false
+        type: string
+
+env:
+  QT_VERSION: "6.8.3"
+
+jobs:
+  resolve-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Resolve package version
+        id: version
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            version="${GITHUB_REF_NAME#v}"
+          elif [[ -n "${INPUT_VERSION}" ]]; then
+            version="${INPUT_VERSION}"
+          else
+            version="0.0.0-dev.${GITHUB_RUN_NUMBER}"
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "Resolved version: ${version}"
+
+  package-windows:
+    runs-on: windows-latest
+    needs: resolve-version
+    env:
+      LINKS_SDK_ARCH: x64
+      LINKS_ENABLE_LOCAL_RECORDING: "ON"
+      VCPKG_TARGET_TRIPLET: x64-windows
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ env.QT_VERSION }}
+          arch: win64_msvc2022_64
+          modules: qtmultimedia
+          cache: true
+
+      - name: Install build and packaging tools
+        shell: pwsh
+        run: |
+          choco install ninja --no-progress -y
+          choco install innosetup --no-progress -y
+
+      - name: Setup vcpkg
+        shell: pwsh
+        run: |
+          if (!(Test-Path "third_party\vcpkg")) {
+            git clone https://github.com/microsoft/vcpkg.git third_party/vcpkg
+          }
+          .\third_party\vcpkg\bootstrap-vcpkg.bat -disableMetrics
+
+      - name: Cache vcpkg packages
+        uses: actions/cache@v4
+        with:
+          path: third_party/vcpkg_installed
+          key: vcpkg-package-Windows-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-package-Windows-
+
+      - name: Build release binary
+        shell: cmd
+        run: build.cmd release
+
+      - name: Prepare Qt runtime package
+        id: package
+        shell: pwsh
+        run: |
+          $workspace = $env:GITHUB_WORKSPACE
+          $version = "${{ needs.resolve-version.outputs.version }}"
+          $distRoot = Join-Path $workspace "dist"
+          $appDir = Join-Path $distRoot "Links"
+          $binDir = Join-Path $workspace "build\bin"
+          $exePath = Join-Path $binDir "links.exe"
+          $qmlSourceDir = Join-Path $workspace "ui\qml"
+
+          if (!(Test-Path $exePath)) { throw "Executable not found: $exePath" }
+          if (!(Test-Path $qmlSourceDir)) { throw "QML source dir not found: $qmlSourceDir" }
+
+          New-Item -ItemType Directory -Force -Path $appDir | Out-Null
+          Copy-Item -Path (Join-Path $binDir "*") -Destination $appDir -Recurse -Force
+
+          $appExePath = Join-Path $appDir "links.exe"
+          & windeployqt.exe --release --compiler-runtime --no-translations --no-opengl-sw --qmldir "$qmlSourceDir" --dir "$appDir" "$appExePath"
+          if ($LASTEXITCODE -ne 0) { throw "windeployqt failed with exit code $LASTEXITCODE" }
+
+          @(
+            "[Paths]",
+            "Prefix=.",
+            "Plugins=.",
+            "Qml2Imports=qml",
+            "Imports=qml"
+          ) | Set-Content -Path (Join-Path $appDir "qt.conf") -Encoding Ascii
+
+          $required = @(
+            "links.exe",
+            "Qt6Core.dll",
+            "Qt6Qml.dll",
+            "Qt6Quick.dll",
+            "platforms\qwindows.dll",
+            "livekit.dll",
+            "livekit_ffi.dll",
+            "webrtc-audio-processing-2-1.dll"
+          )
+          foreach ($relativePath in $required) {
+            $path = Join-Path $appDir $relativePath
+            if (!(Test-Path $path)) { throw "Missing packaged runtime file: $path" }
+          }
+
+          Get-ChildItem -Path $appDir -Recurse -File -Include *.pdb,*.ilk,*.exp,*.lib,*.ipdb,*.iobj |
+            Remove-Item -Force -ErrorAction SilentlyContinue
+
+          $portableZip = Join-Path $distRoot ("Links-v{0}-win-x64-portable.zip" -f $version)
+          if (Test-Path $portableZip) { Remove-Item -Force $portableZip }
+          Push-Location $distRoot
+          try {
+            Compress-Archive -Path "Links" -DestinationPath $portableZip -CompressionLevel Optimal
+          } finally {
+            Pop-Location
+          }
+
+          "dist_dir=$appDir" >> $env:GITHUB_OUTPUT
+          "portable_zip=$portableZip" >> $env:GITHUB_OUTPUT
+
+      - name: Build Inno Setup installer
+        id: installer
+        shell: pwsh
+        run: |
+          $workspace = $env:GITHUB_WORKSPACE
+          $scriptPath = Join-Path $workspace "tools\packaging\windows\links-setup.iss"
+          $distDir = "${{ steps.package.outputs.dist_dir }}"
+          $outputDir = Join-Path $workspace "dist\installer"
+          $isccPath = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+
+          if (!(Test-Path $scriptPath)) { throw "Installer script not found: $scriptPath" }
+          if (!(Test-Path $isccPath)) { throw "ISCC not found: $isccPath" }
+
+          New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
+          & $isccPath "/DSourceRoot=$workspace" "/DDistDir=$distDir" "/DOutputDir=$outputDir" "/DAppVersion=${{ needs.resolve-version.outputs.version }}" "$scriptPath"
+          if ($LASTEXITCODE -ne 0) { throw "ISCC failed with exit code $LASTEXITCODE" }
+
+          $installerFile = Get-ChildItem -Path $outputDir -File -Filter "*.exe" |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+          if ($null -eq $installerFile) { throw "No installer generated in $outputDir" }
+          "installer_exe=$($installerFile.FullName)" >> $env:GITHUB_OUTPUT
+
+      - name: Upload Windows portable package
+        uses: actions/upload-artifact@v4
+        with:
+          name: Links-Windows-x64-portable
+          path: ${{ steps.package.outputs.portable_zip }}
+          if-no-files-found: error
+
+      - name: Upload Windows installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: Links-Windows-x64-setup
+          path: ${{ steps.installer.outputs.installer_exe }}
+          if-no-files-found: error
+
+  package-macos:
+    runs-on: macos-latest
+    needs: resolve-version
+    env:
+      LINKS_SDK_ARCH: arm64
+      LINKS_ENABLE_LOCAL_RECORDING: "OFF"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ env.QT_VERSION }}
+          arch: clang_64
+          modules: qtmultimedia
+          cache: true
+
+      - name: Install Ninja
+        run: brew install ninja
+
+      - name: Setup vcpkg
+        shell: bash
+        run: |
+          if [ ! -d third_party/vcpkg ]; then
+            git clone https://github.com/microsoft/vcpkg.git third_party/vcpkg
+          fi
+          ./third_party/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+      - name: Cache vcpkg packages
+        uses: actions/cache@v4
+        with:
+          path: third_party/vcpkg_installed
+          key: vcpkg-package-macOS-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-package-macOS-
+
+      - name: Build release bundle
+        shell: bash
+        run: |
+          chmod +x ./build.sh
+          ./build.sh release
+
+      - name: Prepare DMG package
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.resolve-version.outputs.version }}"
+          app_path="$GITHUB_WORKSPACE/build/bin/links.app"
+          binary_path="$app_path/Contents/MacOS/links"
+          frameworks_dir="$app_path/Contents/Frameworks"
+          dist_dir="$GITHUB_WORKSPACE/dist"
+
+          if [ ! -d "$app_path" ]; then
+            echo "App bundle not found: $app_path" >&2
+            exit 1
+          fi
+          if [ ! -f "$binary_path" ]; then
+            echo "App binary not found: $binary_path" >&2
+            exit 1
+          fi
+
+          mkdir -p "$frameworks_dir" "$dist_dir"
+
+          livekit_lib="$(find "$GITHUB_WORKSPACE/third_party" -name liblivekit.dylib -print -quit)"
+          livekit_ffi_lib="$(find "$GITHUB_WORKSPACE/third_party" -name liblivekit_ffi.dylib -print -quit)"
+          webrtc_apm_lib="$(find "$GITHUB_WORKSPACE/third_party" -name 'libwebrtc-audio-processing-2.1.dylib' -print -quit)"
+
+          for lib in "$livekit_lib" "$livekit_ffi_lib" "$webrtc_apm_lib"; do
+            if [ -z "$lib" ] || [ ! -f "$lib" ]; then
+              echo "Required dylib not found" >&2
+              exit 1
+            fi
+            cp -f "$lib" "$frameworks_dir/"
+          done
+
+          install_name_tool -add_rpath "@executable_path/../Frameworks" "$binary_path" 2>/dev/null || true
+          while IFS= read -r dep; do
+            base="$(basename "$dep")"
+            install_name_tool -change "$dep" "@executable_path/../Frameworks/$base" "$binary_path" 2>/dev/null || true
+          done < <(otool -L "$binary_path" | awk '/liblivekit|libwebrtc-audio-processing/ {print $1}')
+
+          install_name_tool -id "@rpath/liblivekit.dylib" "$frameworks_dir/liblivekit.dylib" 2>/dev/null || true
+          install_name_tool -id "@rpath/liblivekit_ffi.dylib" "$frameworks_dir/liblivekit_ffi.dylib" 2>/dev/null || true
+          install_name_tool -id "@rpath/libwebrtc-audio-processing-2.1.dylib" "$frameworks_dir/libwebrtc-audio-processing-2.1.dylib" 2>/dev/null || true
+          install_name_tool -change "@rpath/liblivekit.dylib" "@loader_path/liblivekit.dylib" "$frameworks_dir/liblivekit_ffi.dylib" 2>/dev/null || true
+
+          macdeployqt "$app_path" -qmldir="$GITHUB_WORKSPACE/ui/qml" -dmg -verbose=1
+
+          dmg_file="$(find "$GITHUB_WORKSPACE/build/bin" -maxdepth 1 -name '*.dmg' -print -quit)"
+          if [ -z "$dmg_file" ] || [ ! -f "$dmg_file" ]; then
+            echo "macdeployqt did not generate a dmg" >&2
+            exit 1
+          fi
+
+          final_dmg="$dist_dir/Links-v${version}-macos-arm64.dmg"
+          mv -f "$dmg_file" "$final_dmg"
+
+          app_zip="$dist_dir/Links-v${version}-macos-arm64-app.zip"
+          ditto -c -k --sequesterRsrc --keepParent "$app_path" "$app_zip"
+
+          echo "dmg=$final_dmg" >> "$GITHUB_OUTPUT"
+          echo "app_zip=$app_zip" >> "$GITHUB_OUTPUT"
+
+      - name: Upload macOS DMG
+        uses: actions/upload-artifact@v4
+        with:
+          name: Links-macOS-arm64-dmg
+          path: ${{ steps.package.outputs.dmg }}
+          if-no-files-found: error
+
+      - name: Upload macOS app zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: Links-macOS-arm64-app
+          path: ${{ steps.package.outputs.app_zip }}
+          if-no-files-found: error
+
+  package-linux:
+    runs-on: ubuntu-latest
+    needs: resolve-version
+    env:
+      LINKS_SDK_ARCH: x64
+      LINKS_ENABLE_LOCAL_RECORDING: "OFF"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ env.QT_VERSION }}
+          arch: linux_gcc_64
+          modules: qtmultimedia
+          cache: true
+
+      - name: Install Linux build and packaging dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            ninja-build \
+            patchelf \
+            wget \
+            file \
+            libgl1-mesa-dev \
+            libxkbcommon-dev \
+            libxkbcommon-x11-dev \
+            libxcb-xinerama0-dev \
+            libxcb-cursor-dev \
+            libpulse-dev \
+            libasound2-dev
+
+      - name: Setup vcpkg
+        shell: bash
+        run: |
+          if [ ! -d third_party/vcpkg ]; then
+            git clone https://github.com/microsoft/vcpkg.git third_party/vcpkg
+          fi
+          ./third_party/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+      - name: Cache vcpkg packages
+        uses: actions/cache@v4
+        with:
+          path: third_party/vcpkg_installed
+          key: vcpkg-package-Linux-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-package-Linux-
+
+      - name: Build release binary
+        shell: bash
+        run: |
+          chmod +x ./build.sh
+          ./build.sh release
+
+      - name: Build AppImage
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.resolve-version.outputs.version }}"
+          appdir="$GITHUB_WORKSPACE/AppDir"
+          dist_dir="$GITHUB_WORKSPACE/dist"
+          mkdir -p "$dist_dir"
+
+          cmake --install "$GITHUB_WORKSPACE/build" --prefix "$appdir/usr"
+
+          mkdir -p "$appdir/usr/lib"
+          while IFS= read -r lib; do
+            cp -a "$lib" "$appdir/usr/lib/"
+          done < <(find -L "$GITHUB_WORKSPACE/third_party" -type f \( \
+            -name 'liblivekit.so*' -o \
+            -name 'liblivekit_ffi.so*' -o \
+            -name 'libwebrtc-audio-processing-2.so*' \
+          \))
+
+          for required_lib in liblivekit.so liblivekit_ffi.so libwebrtc-audio-processing-2.so; do
+            if ! find "$appdir/usr/lib" -name "${required_lib}*" -print -quit | grep -q .; then
+              echo "Missing copied runtime library: ${required_lib}" >&2
+              exit 1
+            fi
+          done
+
+          if [ ! -f "$appdir/usr/bin/links" ]; then
+            echo "Installed binary missing: $appdir/usr/bin/links" >&2
+            exit 1
+          fi
+          if [ ! -f "$appdir/usr/share/applications/links.desktop" ]; then
+            echo "Desktop file missing from AppDir" >&2
+            exit 1
+          fi
+
+          patchelf --set-rpath '$ORIGIN/../lib' "$appdir/usr/bin/links"
+
+          wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          wget -q https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
+          chmod +x linuxdeploy-x86_64.AppImage linuxdeploy-plugin-qt-x86_64.AppImage
+
+          export APPIMAGE_EXTRACT_AND_RUN=1
+          export QML_SOURCES_PATHS="$GITHUB_WORKSPACE/ui/qml"
+          export OUTPUT="$dist_dir/Links-v${version}-linux-x86_64.AppImage"
+          ./linuxdeploy-x86_64.AppImage --appdir "$appdir" --plugin qt --output appimage
+
+          if [ ! -f "$OUTPUT" ]; then
+            echo "AppImage was not generated: $OUTPUT" >&2
+            exit 1
+          fi
+          chmod +x "$OUTPUT"
+          echo "appimage=$OUTPUT" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Linux AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: Links-Linux-x86_64-AppImage
+          path: ${{ steps.package.outputs.appimage }}
+          if-no-files-found: error
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs:
+      - resolve-version
+      - package-windows
+      - package-macos
+      - package-linux
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Download package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Publish GitHub Release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release-assets/**
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -398,8 +398,19 @@ jobs:
 
           patchelf --set-rpath '$ORIGIN/../lib' "$appdir/usr/bin/links"
 
-          wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-          wget -q https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
+          linuxdeploy_version="1-alpha-20250213-2"
+          linuxdeploy_plugin_qt_version="1-alpha-20250213-2"
+          linuxdeploy_sha256="<REPLACE_WITH_LINUXDEPLOY_SHA256>"
+          linuxdeploy_plugin_qt_sha256="<REPLACE_WITH_LINUXDEPLOY_PLUGIN_QT_SHA256>"
+
+          curl -fsSLo linuxdeploy-x86_64.AppImage \
+            "https://github.com/linuxdeploy/linuxdeploy/releases/download/${linuxdeploy_version}/linuxdeploy-x86_64.AppImage"
+          curl -fsSLo linuxdeploy-plugin-qt-x86_64.AppImage \
+            "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/${linuxdeploy_plugin_qt_version}/linuxdeploy-plugin-qt-x86_64.AppImage"
+
+          printf '%s  %s\n' "$linuxdeploy_sha256" "linuxdeploy-x86_64.AppImage" | sha256sum -c -
+          printf '%s  %s\n' "$linuxdeploy_plugin_qt_sha256" "linuxdeploy-plugin-qt-x86_64.AppImage" | sha256sum -c -
+
           chmod +x linuxdeploy-x86_64.AppImage linuxdeploy-plugin-qt-x86_64.AppImage
 
           export APPIMAGE_EXTRACT_AND_RUN=1

--- a/main.cpp
+++ b/main.cpp
@@ -113,9 +113,9 @@ int main(int argc, char* argv[])
     app.setQuitOnLastWindowClosed(false);
     QQuickWindow::setDefaultAlphaBuffer(true);
 
-    app.setApplicationName("SQLink");
+    app.setApplicationName("Links");
     app.setApplicationVersion("1.0.0");
-    app.setOrganizationName("SQLink");
+    app.setOrganizationName("Links");
 
     QIcon appIcon;
     appIcon.addFile(QStringLiteral(":/res/icon/appIcon/linux/icon_16x16.png"), QSize(16, 16));

--- a/res/linux/links.desktop.in
+++ b/res/linux/links.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Name=SQLink
+Name=Links
 Comment=Real-time video conferencing client
 Exec=links
 Icon=links

--- a/tools/packaging/windows/links-setup.iss
+++ b/tools/packaging/windows/links-setup.iss
@@ -19,7 +19,7 @@
 #endif
 
 [Setup]
-AppId={{8A7D4F1E-3D5D-4B7B-9D47-83D3E0B85E58}
+AppId={{8A7D4F1E-3D5D-4B7B-9D47-83D3E0B85E58}}
 AppName={#MyAppName}
 AppVersion={#AppVersion}
 AppPublisher={#MyAppPublisher}

--- a/tools/packaging/windows/links-setup.iss
+++ b/tools/packaging/windows/links-setup.iss
@@ -1,0 +1,94 @@
+; Links Windows installer script
+
+#define MyAppName "Links"
+#ifndef AppVersion
+  #define AppVersion "0.0.0"
+#endif
+#define MyAppPublisher "Sqhh99"
+#define MyAppURL "https://github.com/Sqhh99/links"
+#define MyAppExeName "links.exe"
+
+#ifndef SourceRoot
+  #define SourceRoot "..\.."
+#endif
+#ifndef DistDir
+  #define DistDir "..\..\dist\Links"
+#endif
+#ifndef OutputDir
+  #define OutputDir "..\..\dist\installer"
+#endif
+
+[Setup]
+AppId={{8A7D4F1E-3D5D-4B7B-9D47-83D3E0B85E58}
+AppName={#MyAppName}
+AppVersion={#AppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}
+DefaultDirName={autopf}\{#MyAppName}
+UninstallDisplayIcon={app}\{#MyAppExeName}
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+DisableProgramGroupPage=yes
+LicenseFile={#SourceRoot}\LICENSE
+OutputDir={#OutputDir}
+OutputBaseFilename=Links-v{#AppVersion}-win-x64-setup
+SetupIconFile={#SourceRoot}\res\icon\appIcon\windows\icon.ico
+Compression=lzma2/ultra64
+SolidCompression=yes
+LZMAUseSeparateProcess=yes
+WizardStyle=modern
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+Source: "{#DistDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+
+[Code]
+var
+  RemoveUserDataOnUninstall: Boolean;
+
+function ConfirmRemoveUserData(): Boolean;
+begin
+  if UninstallSilent then
+  begin
+    Result := False;
+    exit;
+  end;
+
+  Result := MsgBox(
+    'Do you also want to remove Links user data?' + #13#10 +
+    'This includes local settings and cache under AppData.' + #13#10 +
+    'Recorded meeting files will NOT be deleted.',
+    mbConfirmation, MB_YESNO) = IDYES;
+end;
+
+procedure RemoveUserDataDirectories();
+begin
+  DelTree(ExpandConstant('{userappdata}\Links'), True, True, True);
+  DelTree(ExpandConstant('{localappdata}\Links'), True, True, True);
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if CurUninstallStep = usUninstall then
+  begin
+    RemoveUserDataOnUninstall := ConfirmRemoveUserData();
+  end
+  else if (CurUninstallStep = usPostUninstall) and RemoveUserDataOnUninstall then
+  begin
+    RemoveUserDataDirectories();
+  end;
+end;

--- a/tools/packaging/windows/links-setup.iss
+++ b/tools/packaging/windows/links-setup.iss
@@ -71,7 +71,7 @@ begin
   Result := MsgBox(
     'Do you also want to remove Links user data?' + #13#10 +
     'This includes local settings and cache under AppData.' + #13#10 +
-    'Recorded meeting files will NOT be deleted.',
+    'Recorded meeting files stored outside AppData will not be deleted, but any recordings stored under AppData may also be removed.',
     mbConfirmation, MB_YESNO) = IDYES;
 end;
 

--- a/ui/backend/LocalRecordingManager.cpp
+++ b/ui/backend/LocalRecordingManager.cpp
@@ -87,7 +87,7 @@ LocalRecordingManager::LocalRecordingManager(QObject* parent)
         baseDir = QDir::homePath();
     }
 
-    outputDirectory_ = QDir(baseDir).filePath(QStringLiteral("SQLink/Recordings"));
+    outputDirectory_ = QDir(baseDir).filePath(QStringLiteral("Links/Recordings"));
 
     durationTimer_.setInterval(1000);
     durationTimer_.setSingleShot(false);

--- a/ui/backend/LocalRecordingManager.cpp
+++ b/ui/backend/LocalRecordingManager.cpp
@@ -52,6 +52,30 @@ bool shouldSaveDiagnosticFrames()
     return value != "0" && value != "false" && value != "off";
 }
 
+QString recordingBaseDirectory()
+{
+    QString baseDir = QStandardPaths::writableLocation(QStandardPaths::MoviesLocation);
+    if (baseDir.isEmpty()) {
+        baseDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    }
+
+    if (baseDir.isEmpty()) {
+        baseDir = QDir::homePath();
+    }
+
+    return baseDir;
+}
+
+QString currentRecordingDirectory()
+{
+    return QDir(recordingBaseDirectory()).filePath(QStringLiteral("Links/Recordings"));
+}
+
+QString legacyRecordingDirectory()
+{
+    return QDir(recordingBaseDirectory()).filePath(QStringLiteral("SQLink/Recordings"));
+}
+
 #ifndef LINKS_ENABLE_LOCAL_RECORDING
 #define LINKS_ENABLE_LOCAL_RECORDING 1
 #endif
@@ -78,16 +102,7 @@ bool LocalRecordingManager::isAvailable() const
 LocalRecordingManager::LocalRecordingManager(QObject* parent)
     : QObject(parent)
 {
-    QString baseDir = QStandardPaths::writableLocation(QStandardPaths::MoviesLocation);
-    if (baseDir.isEmpty()) {
-        baseDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-    }
-
-    if (baseDir.isEmpty()) {
-        baseDir = QDir::homePath();
-    }
-
-    outputDirectory_ = QDir(baseDir).filePath(QStringLiteral("Links/Recordings"));
+    outputDirectory_ = currentRecordingDirectory();
 
     durationTimer_.setInterval(1000);
     durationTimer_.setSingleShot(false);
@@ -712,18 +727,37 @@ QVariantList LocalRecordingManager::scanRecentRecordings() const
 {
     QVariantList records;
 
-    QDir dir(outputDirectory_);
-    if (!dir.exists()) {
+    QStringList scanDirectories;
+    scanDirectories << outputDirectory_;
+
+    const QString legacyDirectory = legacyRecordingDirectory();
+    if (QDir::cleanPath(legacyDirectory) != QDir::cleanPath(outputDirectory_)) {
+        scanDirectories << legacyDirectory;
+    }
+
+    QFileInfoList files;
+    for (const QString& directory : scanDirectories) {
+        QDir dir(directory);
+        if (!dir.exists()) {
+            continue;
+        }
+
+        files.append(dir.entryInfoList(
+            QStringList() << QStringLiteral("*.mp4")
+                          << QStringLiteral("*.mkv")
+                          << QStringLiteral("*.mov")
+                          << QStringLiteral("*.webm"),
+            QDir::Files | QDir::Readable,
+            QDir::Time));
+    }
+
+    if (files.isEmpty()) {
         return records;
     }
 
-    const QFileInfoList files = dir.entryInfoList(
-        QStringList() << QStringLiteral("*.mp4")
-                      << QStringLiteral("*.mkv")
-                      << QStringLiteral("*.mov")
-                      << QStringLiteral("*.webm"),
-        QDir::Files | QDir::Readable,
-        QDir::Time);
+    std::sort(files.begin(), files.end(), [](const QFileInfo& lhs, const QFileInfo& rhs) {
+        return lhs.lastModified() > rhs.lastModified();
+    });
 
     for (const QFileInfo& file : files) {
 

--- a/utils/settings.cpp
+++ b/utils/settings.cpp
@@ -2,23 +2,77 @@
 #include "logger.h"
 #include <QCoreApplication>
 #include <QDir>
+#include <QFile>
+#include <QFileInfo>
 #include <QStandardPaths>
 
+namespace {
+
+QString genericDataDir()
+{
+    QString baseDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+    if (baseDir.isEmpty()) {
+        baseDir = QDir::homePath();
+    }
+    return baseDir;
+}
+
+QString linksConfigFilePath()
+{
+    return genericDataDir() + "/Links/links_config.ini";
+}
+
+QString legacyConfigFilePath()
+{
+    return genericDataDir() + "/SQLink/sqlink_config.ini";
+}
+
+void ensureConfigDirExists(const QString& configFilePath)
+{
+    QDir dir(QFileInfo(configFilePath).absolutePath());
+    if (!dir.exists() && !dir.mkpath(".")) {
+        Logger::instance().warning(QString("Failed to create settings directory: %1").arg(dir.absolutePath()));
+    }
+}
+
+void migrateLegacyConfigIfNeeded(const QString& configFilePath)
+{
+    if (QFileInfo::exists(configFilePath)) {
+        return;
+    }
+
+    const QString legacyPath = legacyConfigFilePath();
+    if (!QFileInfo::exists(legacyPath)) {
+        return;
+    }
+
+    ensureConfigDirExists(configFilePath);
+    if (QFile::copy(legacyPath, configFilePath)) {
+        Logger::instance().info(QString("Migrated settings from legacy location: %1").arg(legacyPath));
+    } else {
+        Logger::instance().warning(QString("Failed to migrate legacy settings from: %1").arg(legacyPath));
+    }
+}
+
 // Helper function to get the config file path
-static QString getConfigFilePath()
+QString getConfigFilePath()
 {
     // Store the config file under Qt's cross-platform generic data directory,
     // using a "Links" subdirectory (for example, under AppData/Local on Windows).
     // This avoids writing to the installation directory, and GenericDataLocation
     // prevents Qt from appending the organization/app name automatically.
-    QString baseDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
-    QString configDir = baseDir + "/Links";
+    const QString configFilePath = linksConfigFilePath();
+    migrateLegacyConfigIfNeeded(configFilePath);
+
+    QString configDir = QFileInfo(configFilePath).absolutePath();
     QDir dir(configDir);
     if (!dir.exists()) {
         dir.mkpath(".");
     }
-    return configDir + "/links_config.ini";
+    return configFilePath;
 }
+
+} // namespace
 
 Settings& Settings::instance()
 {

--- a/utils/settings.cpp
+++ b/utils/settings.cpp
@@ -7,16 +7,16 @@
 // Helper function to get the config file path
 static QString getConfigFilePath()
 {
-    // Use AppData/Local/SQLink directory for config file
+    // Use AppData/Local/Links directory for config file
     // This works even when app is installed in Program Files (which is read-only)
     // Use GenericDataLocation to avoid Qt appending organization/app name automatically
     QString baseDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
-    QString configDir = baseDir + "/SQLink";
+    QString configDir = baseDir + "/Links";
     QDir dir(configDir);
     if (!dir.exists()) {
         dir.mkpath(".");
     }
-    return configDir + "/sqlink_config.ini";
+    return configDir + "/links_config.ini";
 }
 
 Settings& Settings::instance()

--- a/utils/settings.cpp
+++ b/utils/settings.cpp
@@ -63,12 +63,7 @@ QString getConfigFilePath()
     // prevents Qt from appending the organization/app name automatically.
     const QString configFilePath = linksConfigFilePath();
     migrateLegacyConfigIfNeeded(configFilePath);
-
-    QString configDir = QFileInfo(configFilePath).absolutePath();
-    QDir dir(configDir);
-    if (!dir.exists()) {
-        dir.mkpath(".");
-    }
+    ensureConfigDirExists(configFilePath);
     return configFilePath;
 }
 

--- a/utils/settings.cpp
+++ b/utils/settings.cpp
@@ -7,9 +7,10 @@
 // Helper function to get the config file path
 static QString getConfigFilePath()
 {
-    // Use AppData/Local/Links directory for config file
-    // This works even when app is installed in Program Files (which is read-only)
-    // Use GenericDataLocation to avoid Qt appending organization/app name automatically
+    // Store the config file under Qt's cross-platform generic data directory,
+    // using a "Links" subdirectory (for example, under AppData/Local on Windows).
+    // This avoids writing to the installation directory, and GenericDataLocation
+    // prevents Qt from appending the organization/app name automatically.
     QString baseDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
     QString configDir = baseDir + "/Links";
     QDir dir(configDir);


### PR DESCRIPTION
This pull request updates the application's branding from "SQLink" to "Links" across the codebase, installer scripts, and configuration files. The changes ensure consistency in the application's name, organization, and file paths, and introduce a new Windows installer script for the rebranded application.

Branding and naming updates:

* Changed the application name and organization from "SQLink" to "Links" in `main.cpp`, and updated the desktop entry name in `res/linux/links.desktop.in`. [[1]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL116-R118) [[2]](diffhunk://#diff-1b38f16d4ed75dfc0943e61fc14f0fdd3aa067867e8b1e4f461f2fba699dce8aL3-R3)
* Updated file paths and directory names from "SQLink" to "Links" in the local recordings manager and settings configuration logic (`ui/backend/LocalRecordingManager.cpp`, `utils/settings.cpp`). [[1]](diffhunk://#diff-56ea7a328d41e0f188fd9ebabb4eb60ee888bab74aa8de5f04debfa41e8b2bc8L90-R90) [[2]](diffhunk://#diff-b4412f4ca7c96fdbe0ec2a492bd2bfd8dc4877eb1592dcb3a2cd242baa5a897fL10-R19)

Installer improvements:

* Added a new Windows installer script (`tools/packaging/windows/links-setup.iss`) for the "Links" application, including support for custom user data removal on uninstall and updated metadata to reflect the new branding.