### PR TITLE
fix: adapt local track cleanup for livekit 0.3.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
             qt_arch: linux_gcc_64
             sdk_arch: x64
             recording_enabled: "OFF"
-          - os: macos-latest
+          - os: macos-15-intel
             qt_version: "6.8.3"
             qt_arch: clang_64
-            sdk_arch: arm64
+            sdk_arch: x64
             recording_enabled: "OFF"
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,9 +97,9 @@ jobs:
       uses: actions/cache@v4
       with:
         path: third_party/vcpkg_installed
-        key: vcpkg-${{ runner.os }}-${{ hashFiles('vcpkg.json') }}
+        key: vcpkg-${{ runner.os }}-${{ matrix.sdk_arch }}-${{ hashFiles('vcpkg.json') }}
         restore-keys: |
-          vcpkg-${{ runner.os }}-
+          vcpkg-${{ runner.os }}-${{ matrix.sdk_arch }}-
 
     # Build + Test via repo scripts
     - name: Build and Test (Windows)

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -216,9 +216,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: third_party/vcpkg_installed
-          key: vcpkg-package-macOS-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-package-macOS-${{ env.LINKS_SDK_ARCH }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-package-macOS-
+            vcpkg-package-macOS-${{ env.LINKS_SDK_ARCH }}-
 
       - name: Build release bundle
         shell: bash
@@ -418,6 +418,8 @@ jobs:
 
           export linuxdeploy_version="1-alpha-20250213-2"
           export linuxdeploy_plugin_qt_version="1-alpha-20250213-1"
+          export linuxdeploy_sha256="4648f278ab3ef31f819e67c30d50f462640e5365a77637d7e6f2ad9fd0b4522a"
+          export linuxdeploy_plugin_qt_sha256="15106be885c1c48a021198e7e1e9a48ce9d02a86dd0a1848f00bdbf3c1c92724"
 
           python3 <<'PY'
           import hashlib
@@ -431,11 +433,13 @@ jobs:
                   "linuxdeploy/linuxdeploy",
                   os.environ["linuxdeploy_version"],
                   "linuxdeploy-x86_64.AppImage",
+                  os.environ["linuxdeploy_sha256"],
               ),
               (
                   "linuxdeploy/linuxdeploy-plugin-qt",
                   os.environ["linuxdeploy_plugin_qt_version"],
                   "linuxdeploy-plugin-qt-x86_64.AppImage",
+                  os.environ["linuxdeploy_plugin_qt_sha256"],
               ),
           ]
 
@@ -449,7 +453,7 @@ jobs:
                   headers["Authorization"] = f"Bearer {token}"
               return urllib.request.Request(url, headers=headers)
 
-          for repo, tag, asset_name in ASSETS:
+          for repo, tag, asset_name, expected_sha256 in ASSETS:
               api_url = f"https://api.github.com/repos/{repo}/releases/tags/{tag}"
               with urllib.request.urlopen(request(api_url)) as response:
                   release = json.load(response)
@@ -459,24 +463,16 @@ jobs:
                   print(f"Release asset not found: {repo}@{tag}/{asset_name}", file=sys.stderr)
                   sys.exit(1)
 
-              digest = asset.get("digest") or ""
               url = asset["browser_download_url"]
               with urllib.request.urlopen(request(url)) as response, open(asset_name, "wb") as output:
                   data = response.read()
                   output.write(data)
 
-              if digest.startswith("sha256:"):
-                  actual = hashlib.sha256(data).hexdigest()
-                  expected = digest.removeprefix("sha256:")
-                  if actual.lower() != expected.lower():
-                      print(f"SHA256 mismatch for {asset_name}: expected {expected}, got {actual}", file=sys.stderr)
-                      sys.exit(1)
-                  print(f"Downloaded and verified {asset_name}: sha256:{actual}")
-              else:
-                  print(
-                      f"Warning: release asset has no sha256 digest metadata, skipping verification: {repo}@{tag}/{asset_name}",
-                      file=sys.stderr,
-                  )
+              actual = hashlib.sha256(data).hexdigest()
+              if actual.lower() != expected_sha256.lower():
+                  print(f"SHA256 mismatch for {asset_name}: expected {expected_sha256}, got {actual}", file=sys.stderr)
+                  sys.exit(1)
+              print(f"Downloaded and verified {asset_name}: sha256:{actual}")
           PY
 
           chmod +x linuxdeploy-x86_64.AppImage linuxdeploy-plugin-qt-x86_64.AppImage

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -184,10 +184,10 @@ jobs:
           if-no-files-found: error
 
   package-macos:
-    runs-on: macos-15
+    runs-on: macos-15-intel
     needs: resolve-version
     env:
-      LINKS_SDK_ARCH: arm64
+      LINKS_SDK_ARCH: x64
       LINKS_ENABLE_LOCAL_RECORDING: "OFF"
     steps:
       - name: Checkout repository
@@ -197,7 +197,7 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           version: ${{ env.QT_VERSION }}
-          arch: clang_arm64
+          arch: clang_64
           modules: qtmultimedia
           cache: true
 
@@ -248,8 +248,8 @@ jobs:
 
           binary_arch="$(file "$binary_path")"
           echo "$binary_arch"
-          if [[ "$binary_arch" != *"arm64"* ]]; then
-            echo "Expected arm64 app binary, got: $binary_arch" >&2
+          if [[ "$binary_arch" != *"x86_64"* ]]; then
+            echo "Expected x86_64 app binary, got: $binary_arch" >&2
             exit 1
           fi
 
@@ -273,8 +273,8 @@ jobs:
             "$frameworks_dir/libwebrtc-audio-processing-2.1.dylib"; do
             lib_arch="$(file "$copied_lib")"
             echo "$lib_arch"
-            if [[ "$lib_arch" != *"arm64"* ]]; then
-              echo "Expected arm64 dylib, got: $lib_arch" >&2
+            if [[ "$lib_arch" != *"x86_64"* ]]; then
+              echo "Expected x86_64 dylib, got: $lib_arch" >&2
               exit 1
             fi
           done
@@ -298,10 +298,10 @@ jobs:
             exit 1
           fi
 
-          final_dmg="$dist_dir/Links-v${version}-macos-arm64.dmg"
+          final_dmg="$dist_dir/Links-v${version}-macos-x64.dmg"
           mv -f "$dmg_file" "$final_dmg"
 
-          app_zip="$dist_dir/Links-v${version}-macos-arm64-app.zip"
+          app_zip="$dist_dir/Links-v${version}-macos-x64-app.zip"
           ditto -c -k --sequesterRsrc --keepParent "$app_path" "$app_zip"
 
           echo "dmg=$final_dmg" >> "$GITHUB_OUTPUT"
@@ -310,14 +310,14 @@ jobs:
       - name: Upload macOS DMG
         uses: actions/upload-artifact@v4
         with:
-          name: Links-macOS-arm64-dmg
+          name: Links-macOS-x64-dmg
           path: ${{ steps.package.outputs.dmg }}
           if-no-files-found: error
 
       - name: Upload macOS app zip
         uses: actions/upload-artifact@v4
         with:
-          name: Links-macOS-arm64-app
+          name: Links-macOS-x64-app
           path: ${{ steps.package.outputs.app_zip }}
           if-no-files-found: error
 
@@ -460,22 +460,23 @@ jobs:
                   sys.exit(1)
 
               digest = asset.get("digest") or ""
-              if not digest.startswith("sha256:"):
-                  print(f"Release asset has no sha256 digest: {repo}@{tag}/{asset_name}", file=sys.stderr)
-                  sys.exit(1)
-
               url = asset["browser_download_url"]
               with urllib.request.urlopen(request(url)) as response, open(asset_name, "wb") as output:
                   data = response.read()
                   output.write(data)
 
-              actual = hashlib.sha256(data).hexdigest()
-              expected = digest.removeprefix("sha256:")
-              if actual.lower() != expected.lower():
-                  print(f"SHA256 mismatch for {asset_name}: expected {expected}, got {actual}", file=sys.stderr)
-                  sys.exit(1)
-
-              print(f"Downloaded and verified {asset_name}: sha256:{actual}")
+              if digest.startswith("sha256:"):
+                  actual = hashlib.sha256(data).hexdigest()
+                  expected = digest.removeprefix("sha256:")
+                  if actual.lower() != expected.lower():
+                      print(f"SHA256 mismatch for {asset_name}: expected {expected}, got {actual}", file=sys.stderr)
+                      sys.exit(1)
+                  print(f"Downloaded and verified {asset_name}: sha256:{actual}")
+              else:
+                  print(
+                      f"Warning: release asset has no sha256 digest metadata, skipping verification: {repo}@{tag}/{asset_name}",
+                      file=sys.stderr,
+                  )
           PY
 
           chmod +x linuxdeploy-x86_64.AppImage linuxdeploy-plugin-qt-x86_64.AppImage

--- a/cmake/FetchLiveKitSDK.cmake
+++ b/cmake/FetchLiveKitSDK.cmake
@@ -5,7 +5,7 @@
 
 # Version configuration (can be overridden before including this module)
 if(NOT DEFINED LIVEKIT_SDK_VERSION)
-    set(LIVEKIT_SDK_VERSION "0.3.1")
+    set(LIVEKIT_SDK_VERSION "0.3.4")
 endif()
 
 # Shared SDK architecture selector across third-party fetch modules.
@@ -88,27 +88,59 @@ else()
     message(STATUS "Found LiveKit SDK at ${LIVEKIT_SDK_ROOT}")
 endif()
 
+# Some manually extracted SDK archives contain an extra top-level directory.
+set(LIVEKIT_SDK_RESOLVED_ROOT "${LIVEKIT_SDK_ROOT}")
+if(NOT EXISTS "${LIVEKIT_SDK_RESOLVED_ROOT}/include" AND
+   EXISTS "${LIVEKIT_SDK_ROOT}/${LIVEKIT_SDK_NAME}/include")
+    set(LIVEKIT_SDK_RESOLVED_ROOT "${LIVEKIT_SDK_ROOT}/${LIVEKIT_SDK_NAME}")
+endif()
+
+if(NOT EXISTS "${LIVEKIT_SDK_RESOLVED_ROOT}/include" OR
+   NOT EXISTS "${LIVEKIT_SDK_RESOLVED_ROOT}/lib")
+    message(FATAL_ERROR
+        "Invalid LiveKit SDK layout under ${LIVEKIT_SDK_ROOT}. "
+        "Expected include/ and lib/ either directly under the SDK root or under ${LIVEKIT_SDK_NAME}/.")
+endif()
+
 # =============================================================================
 # Configure SDK paths for find_package
 # =============================================================================
 # Add SDK's CMake config directory to CMAKE_PREFIX_PATH
-list(APPEND CMAKE_PREFIX_PATH "${LIVEKIT_SDK_ROOT}/lib/cmake/LiveKit")
+list(APPEND CMAKE_PREFIX_PATH "${LIVEKIT_SDK_RESOLVED_ROOT}/lib/cmake/LiveKit")
 
 # Export variables for manual configuration (if find_package doesn't work)
-set(LIVEKIT_INCLUDE_DIR "${LIVEKIT_SDK_ROOT}/include")
+set(LIVEKIT_INCLUDE_DIR "${LIVEKIT_SDK_RESOLVED_ROOT}/include")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    set(LIVEKIT_LIBRARY "${LIVEKIT_SDK_ROOT}/lib/livekit.lib")
-    set(LIVEKIT_FFI_LIBRARY "${LIVEKIT_SDK_ROOT}/lib/livekit_ffi.dll.lib")
-    set(LIVEKIT_BIN_DIR "${LIVEKIT_SDK_ROOT}/bin")
+    set(LIVEKIT_LIBRARY "${LIVEKIT_SDK_RESOLVED_ROOT}/lib/livekit.lib")
+    set(LIVEKIT_FFI_LIBRARY "${LIVEKIT_SDK_RESOLVED_ROOT}/lib/livekit_ffi.dll.lib")
+    set(LIVEKIT_BIN_DIR "${LIVEKIT_SDK_RESOLVED_ROOT}/bin")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(LIVEKIT_LIBRARY "${LIVEKIT_SDK_ROOT}/lib/liblivekit.so")
-    set(LIVEKIT_FFI_LIBRARY "${LIVEKIT_SDK_ROOT}/lib/liblivekit_ffi.so")
-    set(LIVEKIT_BIN_DIR "${LIVEKIT_SDK_ROOT}/lib")
+    set(LIVEKIT_LIBRARY "${LIVEKIT_SDK_RESOLVED_ROOT}/lib/liblivekit.so")
+    set(LIVEKIT_FFI_LIBRARY "${LIVEKIT_SDK_RESOLVED_ROOT}/lib/liblivekit_ffi.so")
+    set(LIVEKIT_BIN_DIR "${LIVEKIT_SDK_RESOLVED_ROOT}/lib")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(LIVEKIT_LIBRARY "${LIVEKIT_SDK_ROOT}/lib/liblivekit.dylib")
-    set(LIVEKIT_FFI_LIBRARY "${LIVEKIT_SDK_ROOT}/lib/liblivekit_ffi.dylib")
-    set(LIVEKIT_BIN_DIR "${LIVEKIT_SDK_ROOT}/lib")
+    set(LIVEKIT_LIBRARY "${LIVEKIT_SDK_RESOLVED_ROOT}/lib/liblivekit.dylib")
+    set(LIVEKIT_FFI_LIBRARY "${LIVEKIT_SDK_RESOLVED_ROOT}/lib/liblivekit_ffi.dylib")
+    set(LIVEKIT_BIN_DIR "${LIVEKIT_SDK_RESOLVED_ROOT}/lib")
+endif()
+
+if(NOT EXISTS "${LIVEKIT_INCLUDE_DIR}")
+    message(FATAL_ERROR "LiveKit SDK include directory not found: ${LIVEKIT_INCLUDE_DIR}")
+endif()
+if(NOT EXISTS "${LIVEKIT_LIBRARY}")
+    message(FATAL_ERROR "LiveKit SDK library not found: ${LIVEKIT_LIBRARY}")
+endif()
+if(NOT EXISTS "${LIVEKIT_FFI_LIBRARY}")
+    message(FATAL_ERROR "LiveKit SDK FFI library not found: ${LIVEKIT_FFI_LIBRARY}")
+endif()
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    if(NOT EXISTS "${LIVEKIT_BIN_DIR}/livekit.dll")
+        message(FATAL_ERROR "LiveKit runtime DLL not found: ${LIVEKIT_BIN_DIR}/livekit.dll")
+    endif()
+    if(NOT EXISTS "${LIVEKIT_BIN_DIR}/livekit_ffi.dll")
+        message(FATAL_ERROR "LiveKit FFI runtime DLL not found: ${LIVEKIT_BIN_DIR}/livekit_ffi.dll")
+    endif()
 endif()
 
 if(APPLE)
@@ -153,7 +185,7 @@ if(APPLE)
 endif()
 
 message(STATUS "LiveKit SDK Configuration:")
-message(STATUS "  Root: ${LIVEKIT_SDK_ROOT}")
+message(STATUS "  Root: ${LIVEKIT_SDK_RESOLVED_ROOT}")
 message(STATUS "  Arch: ${LIVEKIT_ARCH}")
 message(STATUS "  Include: ${LIVEKIT_INCLUDE_DIR}")
 message(STATUS "  Library: ${LIVEKIT_LIBRARY}")

--- a/cmake/FetchLiveKitSDK.cmake
+++ b/cmake/FetchLiveKitSDK.cmake
@@ -42,6 +42,23 @@ set(LIVEKIT_SDK_ROOT "${CMAKE_SOURCE_DIR}/third_party/${LIVEKIT_SDK_NAME}")
 set(LIVEKIT_SDK_ARCHIVE "${LIVEKIT_SDK_NAME}.${LIVEKIT_ARCHIVE_EXT}")
 set(LIVEKIT_SDK_URL "https://github.com/livekit/client-sdk-cpp/releases/download/v${LIVEKIT_SDK_VERSION}/${LIVEKIT_SDK_ARCHIVE}")
 
+function(resolve_livekit_sdk_root out_var)
+    set(candidates
+        "${LIVEKIT_SDK_ROOT}"
+        "${LIVEKIT_SDK_ROOT}/${LIVEKIT_SDK_NAME}"
+        "${CMAKE_SOURCE_DIR}/third_party"
+    )
+
+    foreach(candidate IN LISTS candidates)
+        if(EXISTS "${candidate}/include" AND EXISTS "${candidate}/lib")
+            set(${out_var} "${candidate}" PARENT_SCOPE)
+            return()
+        endif()
+    endforeach()
+
+    set(${out_var} "" PARENT_SCOPE)
+endfunction()
+
 # =============================================================================
 # Download and Extract SDK if not present
 # =============================================================================
@@ -73,26 +90,24 @@ if(NOT EXISTS "${LIVEKIT_SDK_ROOT}")
         INPUT "${LIVEKIT_DOWNLOAD_PATH}"
         DESTINATION "${CMAKE_SOURCE_DIR}/third_party"
     )
-    
-    # The archive extracts to a subdirectory with the same name
-    # Check if extraction created the expected directory
-    if(NOT EXISTS "${LIVEKIT_SDK_ROOT}")
-        message(FATAL_ERROR "Failed to extract LiveKit SDK to ${LIVEKIT_SDK_ROOT}")
-    endif()
-    
+
     # Clean up the archive
     file(REMOVE "${LIVEKIT_DOWNLOAD_PATH}")
-    
+
+    resolve_livekit_sdk_root(LIVEKIT_SDK_RESOLVED_ROOT)
+    if(LIVEKIT_SDK_RESOLVED_ROOT STREQUAL "")
+        message(FATAL_ERROR
+            "Failed to extract LiveKit SDK from ${LIVEKIT_SDK_ARCHIVE}. "
+            "Could not find a directory containing include/ and lib/ under ${CMAKE_SOURCE_DIR}/third_party.")
+    endif()
+
     message(STATUS "LiveKit SDK v${LIVEKIT_SDK_VERSION} installed successfully")
 else()
     message(STATUS "Found LiveKit SDK at ${LIVEKIT_SDK_ROOT}")
 endif()
 
-# Some manually extracted SDK archives contain an extra top-level directory.
-set(LIVEKIT_SDK_RESOLVED_ROOT "${LIVEKIT_SDK_ROOT}")
-if(NOT EXISTS "${LIVEKIT_SDK_RESOLVED_ROOT}/include" AND
-   EXISTS "${LIVEKIT_SDK_ROOT}/${LIVEKIT_SDK_NAME}/include")
-    set(LIVEKIT_SDK_RESOLVED_ROOT "${LIVEKIT_SDK_ROOT}/${LIVEKIT_SDK_NAME}")
+if(NOT DEFINED LIVEKIT_SDK_RESOLVED_ROOT OR LIVEKIT_SDK_RESOLVED_ROOT STREQUAL "")
+    resolve_livekit_sdk_root(LIVEKIT_SDK_RESOLVED_ROOT)
 endif()
 
 if(NOT EXISTS "${LIVEKIT_SDK_RESOLVED_ROOT}/include" OR

--- a/cmake/FetchLiveKitSDK.cmake
+++ b/cmake/FetchLiveKitSDK.cmake
@@ -62,8 +62,10 @@ endfunction()
 # =============================================================================
 # Download and Extract SDK if not present
 # =============================================================================
-if(NOT EXISTS "${LIVEKIT_SDK_ROOT}")
-    message(STATUS "LiveKit SDK not found at ${LIVEKIT_SDK_ROOT}")
+resolve_livekit_sdk_root(LIVEKIT_SDK_RESOLVED_ROOT)
+
+if(LIVEKIT_SDK_RESOLVED_ROOT STREQUAL "")
+    message(STATUS "LiveKit SDK not found under ${CMAKE_SOURCE_DIR}/third_party")
     message(STATUS "Downloading LiveKit SDK v${LIVEKIT_SDK_VERSION} for ${LIVEKIT_PLATFORM}-${LIVEKIT_ARCH}...")
     
     set(LIVEKIT_DOWNLOAD_PATH "${CMAKE_SOURCE_DIR}/third_party/${LIVEKIT_SDK_ARCHIVE}")
@@ -103,11 +105,7 @@ if(NOT EXISTS "${LIVEKIT_SDK_ROOT}")
 
     message(STATUS "LiveKit SDK v${LIVEKIT_SDK_VERSION} installed successfully")
 else()
-    message(STATUS "Found LiveKit SDK at ${LIVEKIT_SDK_ROOT}")
-endif()
-
-if(NOT DEFINED LIVEKIT_SDK_RESOLVED_ROOT OR LIVEKIT_SDK_RESOLVED_ROOT STREQUAL "")
-    resolve_livekit_sdk_root(LIVEKIT_SDK_RESOLVED_ROOT)
+    message(STATUS "Found LiveKit SDK at ${LIVEKIT_SDK_RESOLVED_ROOT}")
 endif()
 
 if(NOT EXISTS "${LIVEKIT_SDK_RESOLVED_ROOT}/include" OR

--- a/core/conference/conference_manager.cpp
+++ b/core/conference/conference_manager.cpp
@@ -84,6 +84,8 @@ ConferenceManager::ConferenceManager(QObject* parent)
                      this, &ConferenceManager::onRoomDisconnectedQueued);
     QObject::connect(roomDelegate_.get(), &RoomEventDelegate::dataReceivedQueued,
                      this, &ConferenceManager::onDataReceivedQueued);
+    QObject::connect(roomDelegate_.get(), &RoomEventDelegate::localTrackPublishedQueued,
+                     this, &ConferenceManager::onLocalTrackPublishedQueued);
 
     QObject::connect(deviceController_.get(), &DeviceController::localMicrophoneChanged,
                      this, &ConferenceManager::localMicrophoneChanged);
@@ -125,6 +127,7 @@ void ConferenceManager::connect(const QString& url, const QString& token)
 {
     Logger::instance().info("Connecting to room: " + url);
     lastDisconnectReason_ = livekit::DisconnectReason::Unknown;
+    deviceController_->setRoom(roomController_->room());
 
     try {
         livekit::RoomOptions options;
@@ -146,6 +149,17 @@ void ConferenceManager::connect(const QString& url, const QString& token)
         Logger::instance().error(error);
         emit connectionError(error);
     }
+}
+
+void ConferenceManager::onLocalTrackPublishedQueued(QString publicationSid, int kind, int source)
+{
+    Q_UNUSED(kind);
+    if (!deviceController_) {
+        return;
+    }
+
+    deviceController_->handleLocalTrackPublished(static_cast<livekit::TrackSource>(source),
+                                                publicationSid);
 }
 
 void ConferenceManager::disconnect()

--- a/core/conference/conference_manager.cpp
+++ b/core/conference/conference_manager.cpp
@@ -130,6 +130,7 @@ void ConferenceManager::connect(const QString& url, const QString& token)
         livekit::RoomOptions options;
         options.auto_subscribe = true;
         options.dynacast = false;
+        options.single_peer_connection = true;
 
         bool success = roomController_->connectToRoom(url, token, options);
 
@@ -149,30 +150,21 @@ void ConferenceManager::connect(const QString& url, const QString& token)
 
 void ConferenceManager::disconnect()
 {
+    if (disconnecting_) {
+        Logger::instance().warning("Disconnect requested while cleanup is already in progress");
+        return;
+    }
+
+    disconnecting_ = true;
     Logger::instance().info("Disconnecting from room");
     lastDisconnectReason_ = livekit::DisconnectReason::ClientInitiated;
+    const bool wasConnected = connected_;
+    connected_ = false;
 
-    try {
-        deviceController_->stopCapturers();
-        // Clear streams before room reset so FFI listeners are removed safely.
-        mediaPipeline_->stopAll();
-
-        if (roomController_->room()) {
-            roomController_->clearDelegate();
-
-            if (connected_) {
-                deviceController_->unpublishLocalTracks();
-            }
-
-            Logger::instance().info("Resetting room");
-            roomController_->reset();
-            Logger::instance().info("Room disconnected successfully");
-        }
-
+    auto finalizeDisconnect = [this]() {
         deviceController_->resetLocalState();
         deviceController_->setRoom(roomController_->room());
 
-        connected_ = false;
         participantStore_->clear();
         participantIdentity_.clear();
         networkStatsTimer_.stop();
@@ -180,11 +172,54 @@ void ConferenceManager::disconnect()
 
         emit localConnectionQualityChanged(static_cast<int>(localNetworkQuality_));
         emit localNetworkStatsUpdated(localNetworkStats_);
-
         emit disconnected();
+
+        disconnecting_ = false;
+    };
+
+    try {
+        deviceController_->stopCapturers();
     } catch (const std::exception& e) {
-        Logger::instance().error(QString("Disconnect error: %1").arg(e.what()));
+        Logger::instance().error(QString("Disconnect cleanup error while stopping capturers: %1")
+                                 .arg(e.what()));
     }
+
+    try {
+        // Clear streams before room reset so FFI listeners are removed safely.
+        mediaPipeline_->stopAll();
+    } catch (const std::exception& e) {
+        Logger::instance().error(QString("Disconnect cleanup error while stopping media pipeline: %1")
+                                 .arg(e.what()));
+    }
+
+    if (roomController_->room()) {
+        try {
+            roomController_->clearDelegate();
+        } catch (const std::exception& e) {
+            Logger::instance().error(QString("Disconnect cleanup error while clearing room delegate: %1")
+                                     .arg(e.what()));
+        }
+
+        if (wasConnected) {
+            try {
+                deviceController_->unpublishLocalTracks();
+            } catch (const std::exception& e) {
+                Logger::instance().error(QString("Disconnect cleanup error while unpublishing local tracks: %1")
+                                         .arg(e.what()));
+            }
+        }
+
+        try {
+            Logger::instance().info("Resetting room");
+            roomController_->reset();
+            Logger::instance().info("Room disconnected successfully");
+        } catch (const std::exception& e) {
+            Logger::instance().error(QString("Disconnect cleanup error while resetting room: %1")
+                                     .arg(e.what()));
+        }
+    }
+
+    finalizeDisconnect();
 }
 
 void ConferenceManager::toggleMicrophone()

--- a/core/conference/conference_manager.h
+++ b/core/conference/conference_manager.h
@@ -134,6 +134,7 @@ private:
     void onConnectionStateChangedQueued(int state);
     void onRoomDisconnectedQueued(int reason);
     void onDataReceivedQueued(QByteArray data, QString participantIdentity, QString topic);
+    void onLocalTrackPublishedQueued(QString publicationSid, int kind, int source);
     
     void updateParticipantInfo(const QString& identity);
     void reconcileParticipantsInternal(const char* source);

--- a/core/conference/conference_manager.h
+++ b/core/conference/conference_manager.h
@@ -153,6 +153,7 @@ private:
     QString participantName_;
     QString participantIdentity_;
     bool connected_{false};
+    bool disconnecting_{false};
     livekit::DisconnectReason lastDisconnectReason_{livekit::DisconnectReason::Unknown};
     QTimer networkStatsTimer_;
     NetworkQualityLevel localNetworkQuality_{NetworkQualityLevel::Unknown};

--- a/core/conference/device_controller.cpp
+++ b/core/conference/device_controller.cpp
@@ -2,7 +2,114 @@
 #include "../../utils/logger.h"
 #include "../../utils/settings.h"
 #include "livekit/local_audio_track.h"
+#include "livekit/local_participant.h"
+#include "livekit/local_track_publication.h"
 #include "livekit/local_video_track.h"
+
+namespace {
+
+std::shared_ptr<livekit::LocalTrackPublication>
+resolveTrackPublication(const std::shared_ptr<livekit::Track>& track)
+{
+    if (!track) {
+        return nullptr;
+    }
+
+    if (auto localVideoTrack = std::dynamic_pointer_cast<livekit::LocalVideoTrack>(track)) {
+        return localVideoTrack->publication();
+    }
+
+    if (auto localAudioTrack = std::dynamic_pointer_cast<livekit::LocalAudioTrack>(track)) {
+        return localAudioTrack->publication();
+    }
+
+    return nullptr;
+}
+
+std::string resolvePublishedTrackSid(livekit::LocalParticipant* localParticipant,
+                                     const std::shared_ptr<livekit::Track>& track)
+{
+    if (!track) {
+        return {};
+    }
+
+    if (const auto publication = resolveTrackPublication(track)) {
+        if (!publication->sid().empty()) {
+            return publication->sid();
+        }
+    }
+
+    if (!localParticipant) {
+        return {};
+    }
+
+    const auto publications = localParticipant->trackPublications();
+    for (const auto& entry : publications) {
+        const auto& publication = entry.second;
+        if (!publication) {
+            continue;
+        }
+
+        if (publication->track() == track) {
+            return publication->sid();
+        }
+    }
+
+    return {};
+}
+
+bool isTrackNotFoundError(const std::exception& e)
+{
+    return QString::fromUtf8(e.what()).contains("track not found", Qt::CaseInsensitive);
+}
+
+bool unpublishLocalTrack(livekit::LocalParticipant* localParticipant,
+                         const std::shared_ptr<livekit::Track>& track,
+                         std::string* cachedPublicationSid,
+                         const QString& label,
+                         bool suppressTrackNotFound)
+{
+    if (!localParticipant || !track) {
+        return false;
+    }
+
+    const std::string publicationSid = (cachedPublicationSid && !cachedPublicationSid->empty())
+        ? *cachedPublicationSid
+        : resolvePublishedTrackSid(localParticipant, track);
+    if (publicationSid.empty()) {
+        Logger::instance().warning(QString("Skipping unpublish for %1: publication SID is unavailable")
+                                   .arg(label));
+        track->setPublication(nullptr);
+        if (cachedPublicationSid) {
+            cachedPublicationSid->clear();
+        }
+        return false;
+    }
+
+    try {
+        Logger::instance().info(QString("Unpublishing %1 (publication SID: %2)")
+                                .arg(label, QString::fromStdString(publicationSid)));
+        localParticipant->unpublishTrack(publicationSid);
+        track->setPublication(nullptr);
+        if (cachedPublicationSid) {
+            cachedPublicationSid->clear();
+        }
+        return true;
+    } catch (const std::exception& e) {
+        if (suppressTrackNotFound && isTrackNotFoundError(e)) {
+            Logger::instance().warning(QString("Suppressing missing-publication error while unpublishing %1: %2")
+                                       .arg(label, QString::fromUtf8(e.what())));
+            track->setPublication(nullptr);
+            if (cachedPublicationSid) {
+                cachedPublicationSid->clear();
+            }
+            return false;
+        }
+        throw;
+    }
+}
+
+} // namespace
 
 DeviceController::DeviceController(livekit::Room* room, QObject* parent)
     : QObject(parent),
@@ -66,11 +173,18 @@ DeviceController::DeviceController(livekit::Room* room, QObject* parent)
         Logger::instance().error(QString("Screen capture error: %1").arg(msg));
         if (screenShareEnabled_) {
             screenCapturer_->stop();
-            auto localParticipant = room_->localParticipant();
+            auto localParticipant = room_ ? room_->localParticipant() : nullptr;
             if (localParticipant && localScreenTrack_) {
-                localParticipant->unpublishTrack(localScreenTrack_->sid());
-                localScreenTrack_ = nullptr;
+                try {
+                    unpublishLocalTrack(localParticipant, localScreenTrack_, &screenTrackSid_,
+                                        QStringLiteral("screen share track"), true);
+                } catch (const std::exception& e) {
+                    Logger::instance().warning(QString("Failed to unpublish screen share track after capture error: %1")
+                                               .arg(e.what()));
+                }
             }
+            localScreenTrack_ = nullptr;
+            screenTrackSid_.clear();
             screenShareEnabled_ = false;
             emit localScreenShareChanged(false);
         }
@@ -106,19 +220,34 @@ void DeviceController::unpublishLocalTracks()
         return;
     }
 
-    if (localAudioTrack_ && !localAudioTrack_->sid().empty()) {
-        Logger::instance().info("Unpublishing audio track");
-        localParticipant->unpublishTrack(localAudioTrack_->sid());
+    if (localAudioTrack_) {
+        try {
+            unpublishLocalTrack(localParticipant, localAudioTrack_, nullptr,
+                                QStringLiteral("audio track"), true);
+        } catch (const std::exception& e) {
+            Logger::instance().warning(QString("Failed to unpublish audio track during disconnect: %1")
+                                       .arg(e.what()));
+        }
     }
 
-    if (!cameraTrackSid_.empty()) {
-        Logger::instance().info("Unpublishing camera track");
-        localParticipant->unpublishTrack(cameraTrackSid_);
+    if (localVideoTrack_) {
+        try {
+            unpublishLocalTrack(localParticipant, localVideoTrack_, &cameraTrackSid_,
+                                QStringLiteral("camera track"), true);
+        } catch (const std::exception& e) {
+            Logger::instance().warning(QString("Failed to unpublish camera track during disconnect: %1")
+                                       .arg(e.what()));
+        }
     }
 
-    if (!screenTrackSid_.empty()) {
-        Logger::instance().info("Unpublishing screen share track");
-        localParticipant->unpublishTrack(screenTrackSid_);
+    if (localScreenTrack_) {
+        try {
+            unpublishLocalTrack(localParticipant, localScreenTrack_, &screenTrackSid_,
+                                QStringLiteral("screen share track"), true);
+        } catch (const std::exception& e) {
+            Logger::instance().warning(QString("Failed to unpublish screen share track during disconnect: %1")
+                                       .arg(e.what()));
+        }
     }
 }
 
@@ -175,7 +304,8 @@ void DeviceController::toggleMicrophone()
 
             auto localParticipant = room_->localParticipant();
             if (localParticipant && localAudioTrack_) {
-                localParticipant->unpublishTrack(localAudioTrack_->sid());
+                unpublishLocalTrack(localParticipant, localAudioTrack_, nullptr,
+                                    QStringLiteral("audio track"), true);
                 localAudioTrack_ = nullptr;
             }
         }
@@ -216,11 +346,13 @@ void DeviceController::toggleCamera()
                         Logger::instance().info("Publishing video track...");
                         livekit::TrackPublishOptions options;
                         options.source = livekit::TrackSource::SOURCE_CAMERA;
-                        auto publication = localParticipant->publishTrack(localVideoTrack_, options);
-                        if (publication) {
-                            cameraTrackSid_ = publication->sid();
+                        localParticipant->publishTrack(localVideoTrack_, options);
+                        cameraTrackSid_ = resolvePublishedTrackSid(localParticipant, localVideoTrack_);
+                        if (!cameraTrackSid_.empty()) {
                             Logger::instance().info(QString("Video track published with SID: %1")
                                 .arg(QString::fromStdString(cameraTrackSid_)));
+                        } else {
+                            Logger::instance().warning("Video track published but SID is not available yet");
                         }
                     }
                 }
@@ -232,11 +364,9 @@ void DeviceController::toggleCamera()
             cameraCapturer_->stop();
 
             auto localParticipant = room_->localParticipant();
-            if (localParticipant && !cameraTrackSid_.empty()) {
-                Logger::instance().info(QString("Unpublishing camera track: %1")
-                    .arg(QString::fromStdString(cameraTrackSid_)));
-                localParticipant->unpublishTrack(cameraTrackSid_);
-                cameraTrackSid_.clear();
+            if (localParticipant && localVideoTrack_) {
+                unpublishLocalTrack(localParticipant, localVideoTrack_, &cameraTrackSid_,
+                                    QStringLiteral("camera track"), true);
                 localVideoTrack_ = nullptr;
             }
         }
@@ -275,11 +405,13 @@ void DeviceController::toggleScreenShare()
                 if (localParticipant && localScreenTrack_) {
                     livekit::TrackPublishOptions options;
                     options.source = livekit::TrackSource::SOURCE_SCREENSHARE;
-                    auto publication = localParticipant->publishTrack(localScreenTrack_, options);
-                    if (publication) {
-                        screenTrackSid_ = publication->sid();
+                    localParticipant->publishTrack(localScreenTrack_, options);
+                    screenTrackSid_ = resolvePublishedTrackSid(localParticipant, localScreenTrack_);
+                    if (!screenTrackSid_.empty()) {
                         Logger::instance().info(QString("Screen share track published with SID: %1")
                             .arg(QString::fromStdString(screenTrackSid_)));
+                    } else {
+                        Logger::instance().warning("Screen share track published but SID is not available yet");
                     }
                 }
             } else {
@@ -290,12 +422,10 @@ void DeviceController::toggleScreenShare()
             screenCapturer_->stop();
 
             auto localParticipant = room_->localParticipant();
-            if (localParticipant && !screenTrackSid_.empty()) {
-                Logger::instance().info(QString("Unpublishing screen track: %1")
-                    .arg(QString::fromStdString(screenTrackSid_)));
-                localParticipant->unpublishTrack(screenTrackSid_);
+            if (localParticipant && localScreenTrack_) {
+                unpublishLocalTrack(localParticipant, localScreenTrack_, &screenTrackSid_,
+                                    QStringLiteral("screen share track"), true);
                 Logger::instance().info("Screen track unpublished, releasing reference");
-                screenTrackSid_.clear();
                 localScreenTrack_.reset();
                 Logger::instance().info("Screen track reference released");
             }
@@ -333,7 +463,8 @@ void DeviceController::switchCamera(const QString& deviceId)
 
             auto localParticipant = room_->localParticipant();
             if (localParticipant && localVideoTrack_) {
-                localParticipant->unpublishTrack(localVideoTrack_->sid());
+                unpublishLocalTrack(localParticipant, localVideoTrack_, &cameraTrackSid_,
+                                    QStringLiteral("camera track"), true);
                 localVideoTrack_ = nullptr;
             }
         }
@@ -354,7 +485,11 @@ void DeviceController::switchCamera(const QString& deviceId)
                         livekit::TrackPublishOptions options;
                         options.source = livekit::TrackSource::SOURCE_CAMERA;
                         localParticipant->publishTrack(localVideoTrack_, options);
-                        Logger::instance().info("Camera switched and republished successfully");
+                        cameraTrackSid_ = resolvePublishedTrackSid(localParticipant, localVideoTrack_);
+                        Logger::instance().info(QString("Camera switched and republished successfully%1")
+                            .arg(cameraTrackSid_.empty()
+                                ? QString()
+                                : QStringLiteral(": ") + QString::fromStdString(cameraTrackSid_)));
                     }
                 }
             } else {
@@ -386,7 +521,8 @@ void DeviceController::switchMicrophone(const QString& deviceId)
 
             auto localParticipant = room_->localParticipant();
             if (localParticipant && localAudioTrack_) {
-                localParticipant->unpublishTrack(localAudioTrack_->sid());
+                unpublishLocalTrack(localParticipant, localAudioTrack_, nullptr,
+                                    QStringLiteral("audio track"), true);
                 localAudioTrack_ = nullptr;
             }
         }

--- a/core/conference/device_controller.cpp
+++ b/core/conference/device_controller.cpp
@@ -79,10 +79,6 @@ bool unpublishLocalTrack(livekit::LocalParticipant* localParticipant,
     if (publicationSid.empty()) {
         Logger::instance().warning(QString("Skipping unpublish for %1: publication SID is unavailable")
                                    .arg(label));
-        track->setPublication(nullptr);
-        if (cachedPublicationSid) {
-            cachedPublicationSid->clear();
-        }
         return false;
     }
 

--- a/core/conference/device_controller.cpp
+++ b/core/conference/device_controller.cpp
@@ -63,14 +63,26 @@ bool isTrackNotFoundError(const std::exception& e)
     return QString::fromUtf8(e.what()).contains("track not found", Qt::CaseInsensitive);
 }
 
-bool unpublishLocalTrack(livekit::LocalParticipant* localParticipant,
-                         const std::shared_ptr<livekit::Track>& track,
-                         std::string* cachedPublicationSid,
-                         const QString& label,
-                         bool suppressTrackNotFound)
+enum class UnpublishOutcome {
+    Unpublished,
+    PublicationUnavailable,
+    AlreadyGone,
+    NoTrack,
+    NoParticipant,
+};
+
+UnpublishOutcome unpublishLocalTrack(livekit::LocalParticipant* localParticipant,
+                                     const std::shared_ptr<livekit::Track>& track,
+                                     std::string* cachedPublicationSid,
+                                     const QString& label,
+                                     bool suppressTrackNotFound)
 {
-    if (!localParticipant || !track) {
-        return false;
+    if (!track) {
+        return UnpublishOutcome::NoTrack;
+    }
+
+    if (!localParticipant) {
+        return UnpublishOutcome::NoParticipant;
     }
 
     const std::string publicationSid = (cachedPublicationSid && !cachedPublicationSid->empty())
@@ -79,7 +91,7 @@ bool unpublishLocalTrack(livekit::LocalParticipant* localParticipant,
     if (publicationSid.empty()) {
         Logger::instance().warning(QString("Skipping unpublish for %1: publication SID is unavailable")
                                    .arg(label));
-        return false;
+        return UnpublishOutcome::PublicationUnavailable;
     }
 
     try {
@@ -90,7 +102,7 @@ bool unpublishLocalTrack(livekit::LocalParticipant* localParticipant,
         if (cachedPublicationSid) {
             cachedPublicationSid->clear();
         }
-        return true;
+        return UnpublishOutcome::Unpublished;
     } catch (const std::exception& e) {
         if (suppressTrackNotFound && isTrackNotFoundError(e)) {
             Logger::instance().warning(QString("Suppressing missing-publication error while unpublishing %1: %2")
@@ -99,7 +111,7 @@ bool unpublishLocalTrack(livekit::LocalParticipant* localParticipant,
             if (cachedPublicationSid) {
                 cachedPublicationSid->clear();
             }
-            return false;
+            return UnpublishOutcome::AlreadyGone;
         }
         throw;
     }
@@ -172,17 +184,23 @@ DeviceController::DeviceController(livekit::Room* room, QObject* parent)
             auto localParticipant = room_ ? room_->localParticipant() : nullptr;
             if (localParticipant && localScreenTrack_) {
                 try {
-                    unpublishLocalTrack(localParticipant, localScreenTrack_, &screenTrackSid_,
-                                        QStringLiteral("screen share track"), true);
+                    const UnpublishOutcome outcome =
+                        unpublishLocalTrack(localParticipant, localScreenTrack_, &screenTrackSid_,
+                                            QStringLiteral("screen share track"), true);
+                    if (outcome == UnpublishOutcome::Unpublished
+                        || outcome == UnpublishOutcome::AlreadyGone
+                        || outcome == UnpublishOutcome::NoParticipant
+                        || outcome == UnpublishOutcome::NoTrack) {
+                        finalizeScreenShareDisabled();
+                        return;
+                    }
                 } catch (const std::exception& e) {
                     Logger::instance().warning(QString("Failed to unpublish screen share track after capture error: %1")
                                                .arg(e.what()));
                 }
             }
-            localScreenTrack_ = nullptr;
-            screenTrackSid_.clear();
-            screenShareEnabled_ = false;
-            emit localScreenShareChanged(false);
+            pendingDisableScreenShare_ = true;
+            Logger::instance().warning("Deferring screen share shutdown until publication SID becomes available");
         }
     });
 }
@@ -218,7 +236,7 @@ void DeviceController::unpublishLocalTracks()
 
     if (localAudioTrack_) {
         try {
-            unpublishLocalTrack(localParticipant, localAudioTrack_, nullptr,
+            unpublishLocalTrack(localParticipant, localAudioTrack_, &audioTrackSid_,
                                 QStringLiteral("audio track"), true);
         } catch (const std::exception& e) {
             Logger::instance().warning(QString("Failed to unpublish audio track during disconnect: %1")
@@ -252,15 +270,117 @@ void DeviceController::resetLocalState()
     localVideoTrack_ = nullptr;
     localAudioTrack_ = nullptr;
     localScreenTrack_ = nullptr;
+    audioTrackSid_.clear();
     cameraTrackSid_.clear();
     screenTrackSid_.clear();
     cameraEnabled_ = false;
     microphoneEnabled_ = false;
     screenShareEnabled_ = false;
+    pendingDisableCamera_ = false;
+    pendingDisableMicrophone_ = false;
+    pendingDisableScreenShare_ = false;
+}
+
+void DeviceController::handleLocalTrackPublished(livekit::TrackSource source, const QString& publicationSid)
+{
+    auto localParticipant = room_ ? room_->localParticipant() : nullptr;
+    if (!localParticipant) {
+        return;
+    }
+
+    const std::string sid = publicationSid.toStdString();
+    UnpublishOutcome outcome = UnpublishOutcome::NoTrack;
+
+    switch (source) {
+    case livekit::TrackSource::SOURCE_MICROPHONE:
+        audioTrackSid_ = sid;
+        if (!pendingDisableMicrophone_ || !localAudioTrack_) {
+            return;
+        }
+        outcome = unpublishLocalTrack(localParticipant, localAudioTrack_, &audioTrackSid_,
+                                      QStringLiteral("audio track"), true);
+        if (outcome == UnpublishOutcome::Unpublished
+            || outcome == UnpublishOutcome::AlreadyGone
+            || outcome == UnpublishOutcome::NoParticipant
+            || outcome == UnpublishOutcome::NoTrack) {
+            finalizeMicrophoneDisabled();
+        }
+        return;
+    case livekit::TrackSource::SOURCE_CAMERA:
+        cameraTrackSid_ = sid;
+        if (!pendingDisableCamera_ || !localVideoTrack_) {
+            return;
+        }
+        outcome = unpublishLocalTrack(localParticipant, localVideoTrack_, &cameraTrackSid_,
+                                      QStringLiteral("camera track"), true);
+        if (outcome == UnpublishOutcome::Unpublished
+            || outcome == UnpublishOutcome::AlreadyGone
+            || outcome == UnpublishOutcome::NoParticipant
+            || outcome == UnpublishOutcome::NoTrack) {
+            finalizeCameraDisabled();
+        }
+        return;
+    case livekit::TrackSource::SOURCE_SCREENSHARE:
+        screenTrackSid_ = sid;
+        if (!pendingDisableScreenShare_ || !localScreenTrack_) {
+            return;
+        }
+        outcome = unpublishLocalTrack(localParticipant, localScreenTrack_, &screenTrackSid_,
+                                      QStringLiteral("screen share track"), true);
+        if (outcome == UnpublishOutcome::Unpublished
+            || outcome == UnpublishOutcome::AlreadyGone
+            || outcome == UnpublishOutcome::NoParticipant
+            || outcome == UnpublishOutcome::NoTrack) {
+            finalizeScreenShareDisabled();
+        }
+        return;
+    default:
+        return;
+    }
+}
+
+void DeviceController::finalizeMicrophoneDisabled()
+{
+    localAudioTrack_ = nullptr;
+    audioTrackSid_.clear();
+    pendingDisableMicrophone_ = false;
+    if (microphoneEnabled_) {
+        microphoneEnabled_ = false;
+        emit localMicrophoneChanged(false);
+    }
+}
+
+void DeviceController::finalizeCameraDisabled()
+{
+    localVideoTrack_ = nullptr;
+    cameraTrackSid_.clear();
+    pendingDisableCamera_ = false;
+    if (cameraEnabled_) {
+        cameraEnabled_ = false;
+        emit localCameraChanged(false);
+    }
+}
+
+void DeviceController::finalizeScreenShareDisabled()
+{
+    Logger::instance().info("Screen track unpublished, releasing reference");
+    localScreenTrack_.reset();
+    screenTrackSid_.clear();
+    pendingDisableScreenShare_ = false;
+    Logger::instance().info("Screen track reference released");
+    if (screenShareEnabled_) {
+        screenShareEnabled_ = false;
+        emit localScreenShareChanged(false);
+    }
 }
 
 void DeviceController::toggleMicrophone()
 {
+    if (pendingDisableMicrophone_) {
+        Logger::instance().warning("Ignoring microphone toggle while disable is pending");
+        return;
+    }
+
     microphoneEnabled_ = !microphoneEnabled_;
     Logger::instance().info(QString("Microphone toggled: %1").arg(microphoneEnabled_ ? "ON" : "OFF"));
 
@@ -287,6 +407,7 @@ void DeviceController::toggleMicrophone()
                         Logger::instance().info("Publishing audio track...");
                         livekit::TrackPublishOptions options;
                         options.source = livekit::TrackSource::SOURCE_MICROPHONE;
+                        audioTrackSid_.clear();
                         localParticipant->publishTrack(localAudioTrack_, options);
                         Logger::instance().info("Audio track published successfully");
                     }
@@ -300,9 +421,20 @@ void DeviceController::toggleMicrophone()
 
             auto localParticipant = room_->localParticipant();
             if (localParticipant && localAudioTrack_) {
-                unpublishLocalTrack(localParticipant, localAudioTrack_, nullptr,
-                                    QStringLiteral("audio track"), true);
-                localAudioTrack_ = nullptr;
+                const UnpublishOutcome outcome =
+                    unpublishLocalTrack(localParticipant, localAudioTrack_, &audioTrackSid_,
+                                        QStringLiteral("audio track"), true);
+                if (outcome == UnpublishOutcome::PublicationUnavailable) {
+                    pendingDisableMicrophone_ = true;
+                    microphoneEnabled_ = true;
+                    Logger::instance().warning("Deferring microphone shutdown until publication SID becomes available");
+                    return;
+                }
+                finalizeMicrophoneDisabled();
+                return;
+            } else {
+                finalizeMicrophoneDisabled();
+                return;
             }
         }
     } catch (const std::exception& e) {
@@ -315,6 +447,11 @@ void DeviceController::toggleMicrophone()
 
 void DeviceController::toggleCamera()
 {
+    if (pendingDisableCamera_) {
+        Logger::instance().warning("Ignoring camera toggle while disable is pending");
+        return;
+    }
+
     cameraEnabled_ = !cameraEnabled_;
     Logger::instance().info(QString("Camera toggled: %1").arg(cameraEnabled_ ? "ON" : "OFF"));
 
@@ -342,6 +479,7 @@ void DeviceController::toggleCamera()
                         Logger::instance().info("Publishing video track...");
                         livekit::TrackPublishOptions options;
                         options.source = livekit::TrackSource::SOURCE_CAMERA;
+                        cameraTrackSid_.clear();
                         localParticipant->publishTrack(localVideoTrack_, options);
                         cameraTrackSid_ = resolvePublishedTrackSid(localParticipant, localVideoTrack_);
                         if (!cameraTrackSid_.empty()) {
@@ -361,9 +499,20 @@ void DeviceController::toggleCamera()
 
             auto localParticipant = room_->localParticipant();
             if (localParticipant && localVideoTrack_) {
-                unpublishLocalTrack(localParticipant, localVideoTrack_, &cameraTrackSid_,
-                                    QStringLiteral("camera track"), true);
-                localVideoTrack_ = nullptr;
+                const UnpublishOutcome outcome =
+                    unpublishLocalTrack(localParticipant, localVideoTrack_, &cameraTrackSid_,
+                                        QStringLiteral("camera track"), true);
+                if (outcome == UnpublishOutcome::PublicationUnavailable) {
+                    pendingDisableCamera_ = true;
+                    cameraEnabled_ = true;
+                    Logger::instance().warning("Deferring camera shutdown until publication SID becomes available");
+                    return;
+                }
+                finalizeCameraDisabled();
+                return;
+            } else {
+                finalizeCameraDisabled();
+                return;
             }
         }
     } catch (const std::exception& e) {
@@ -376,6 +525,11 @@ void DeviceController::toggleCamera()
 
 void DeviceController::toggleScreenShare()
 {
+    if (pendingDisableScreenShare_) {
+        Logger::instance().warning("Ignoring screen share toggle while disable is pending");
+        return;
+    }
+
     if (screenShareDebounceTimer_.isValid()
         && screenShareDebounceTimer_.elapsed() < kScreenShareDebounceMs) {
         Logger::instance().warning("Screen share toggle debounced, ignoring rapid toggle");
@@ -401,6 +555,7 @@ void DeviceController::toggleScreenShare()
                 if (localParticipant && localScreenTrack_) {
                     livekit::TrackPublishOptions options;
                     options.source = livekit::TrackSource::SOURCE_SCREENSHARE;
+                    screenTrackSid_.clear();
                     localParticipant->publishTrack(localScreenTrack_, options);
                     screenTrackSid_ = resolvePublishedTrackSid(localParticipant, localScreenTrack_);
                     if (!screenTrackSid_.empty()) {
@@ -419,11 +574,20 @@ void DeviceController::toggleScreenShare()
 
             auto localParticipant = room_->localParticipant();
             if (localParticipant && localScreenTrack_) {
-                unpublishLocalTrack(localParticipant, localScreenTrack_, &screenTrackSid_,
-                                    QStringLiteral("screen share track"), true);
-                Logger::instance().info("Screen track unpublished, releasing reference");
-                localScreenTrack_.reset();
-                Logger::instance().info("Screen track reference released");
+                const UnpublishOutcome outcome =
+                    unpublishLocalTrack(localParticipant, localScreenTrack_, &screenTrackSid_,
+                                        QStringLiteral("screen share track"), true);
+                if (outcome == UnpublishOutcome::PublicationUnavailable) {
+                    pendingDisableScreenShare_ = true;
+                    screenShareEnabled_ = true;
+                    Logger::instance().warning("Deferring screen share shutdown until publication SID becomes available");
+                    return;
+                }
+                finalizeScreenShareDisabled();
+                return;
+            } else {
+                finalizeScreenShareDisabled();
+                return;
             }
         }
     } catch (const std::exception& e) {
@@ -453,16 +617,18 @@ void DeviceController::switchCamera(const QString& deviceId)
 
     try {
         const bool wasEnabled = cameraEnabled_;
+        auto localParticipant = room_ ? room_->localParticipant() : nullptr;
 
-        if (cameraEnabled_) {
-            cameraCapturer_->stop();
-
-            auto localParticipant = room_->localParticipant();
-            if (localParticipant && localVideoTrack_) {
+        if (cameraEnabled_ && localVideoTrack_) {
+            const UnpublishOutcome outcome =
                 unpublishLocalTrack(localParticipant, localVideoTrack_, &cameraTrackSid_,
                                     QStringLiteral("camera track"), true);
-                localVideoTrack_ = nullptr;
+            if (outcome == UnpublishOutcome::PublicationUnavailable) {
+                Logger::instance().warning("Deferring camera switch until current publication SID becomes available");
+                return;
             }
+            cameraCapturer_->stop();
+            localVideoTrack_ = nullptr;
         }
 
         const bool switched = cameraCapturer_->setCameraById(deviceId.toUtf8());
@@ -476,7 +642,6 @@ void DeviceController::switchCamera(const QString& deviceId)
                 if (source) {
                     localVideoTrack_ = livekit::LocalVideoTrack::createLocalVideoTrack("camera", source);
 
-                    auto localParticipant = room_->localParticipant();
                     if (localParticipant && localVideoTrack_) {
                         livekit::TrackPublishOptions options;
                         options.source = livekit::TrackSource::SOURCE_CAMERA;
@@ -511,16 +676,18 @@ void DeviceController::switchMicrophone(const QString& deviceId)
 
     try {
         const bool wasEnabled = microphoneEnabled_;
+        auto localParticipant = room_ ? room_->localParticipant() : nullptr;
 
-        if (microphoneEnabled_) {
-            microphoneCapturer_->stop();
-
-            auto localParticipant = room_->localParticipant();
-            if (localParticipant && localAudioTrack_) {
-                unpublishLocalTrack(localParticipant, localAudioTrack_, nullptr,
+        if (microphoneEnabled_ && localAudioTrack_) {
+            const UnpublishOutcome outcome =
+                unpublishLocalTrack(localParticipant, localAudioTrack_, &audioTrackSid_,
                                     QStringLiteral("audio track"), true);
-                localAudioTrack_ = nullptr;
+            if (outcome == UnpublishOutcome::PublicationUnavailable) {
+                Logger::instance().warning("Deferring microphone switch until current publication SID becomes available");
+                return;
             }
+            microphoneCapturer_->stop();
+            localAudioTrack_ = nullptr;
         }
 
         microphoneCapturer_->setDeviceById(deviceId.toUtf8());
@@ -531,10 +698,10 @@ void DeviceController::switchMicrophone(const QString& deviceId)
                 if (source) {
                     localAudioTrack_ = livekit::LocalAudioTrack::createLocalAudioTrack("mic", source);
 
-                    auto localParticipant = room_->localParticipant();
                     if (localParticipant && localAudioTrack_) {
                         livekit::TrackPublishOptions options;
                         options.source = livekit::TrackSource::SOURCE_MICROPHONE;
+                        audioTrackSid_.clear();
                         localParticipant->publishTrack(localAudioTrack_, options);
                         Logger::instance().info("Microphone switched and republished successfully");
                     }

--- a/core/conference/device_controller.h
+++ b/core/conference/device_controller.h
@@ -23,6 +23,7 @@ public:
     void stopCapturers();
     void unpublishLocalTracks();
     void resetLocalState();
+    void handleLocalTrackPublished(livekit::TrackSource source, const QString& publicationSid);
 
     void toggleMicrophone();
     void toggleCamera();
@@ -68,6 +69,9 @@ signals:
 
 private:
     void connectScreenSignals();
+    void finalizeMicrophoneDisabled();
+    void finalizeCameraDisabled();
+    void finalizeScreenShareDisabled();
     livekit::Room* room() const { return room_; }
 
     livekit::Room* room_{nullptr};
@@ -77,12 +81,16 @@ private:
     std::shared_ptr<livekit::Track> localVideoTrack_;
     std::shared_ptr<livekit::Track> localAudioTrack_;
     std::shared_ptr<livekit::Track> localScreenTrack_;
+    std::string audioTrackSid_;
     std::string screenTrackSid_;
     std::string cameraTrackSid_;
 
     bool cameraEnabled_{false};
     bool microphoneEnabled_{false};
     bool screenShareEnabled_{false};
+    bool pendingDisableCamera_{false};
+    bool pendingDisableMicrophone_{false};
+    bool pendingDisableScreenShare_{false};
 
     QElapsedTimer screenShareDebounceTimer_;
     static constexpr int kScreenShareDebounceMs = 500;

--- a/core/conference/room_controller.cpp
+++ b/core/conference/room_controller.cpp
@@ -1,8 +1,8 @@
 #include "room_controller.h"
 
 RoomController::RoomController()
-    : room_(std::make_unique<livekit::Room>())
 {
+    ensureRoom();
 }
 
 livekit::Room* RoomController::room() const
@@ -12,9 +12,9 @@ livekit::Room* RoomController::room() const
 
 void RoomController::setDelegate(livekit::RoomDelegate* delegate)
 {
-    if (room_) {
-        room_->setDelegate(delegate);
-    }
+    delegate_ = delegate;
+    ensureRoom();
+    room_->setDelegate(delegate);
 }
 
 void RoomController::clearDelegate()
@@ -28,12 +28,14 @@ bool RoomController::connectToRoom(const QString& url,
                                    const QString& token,
                                    const livekit::RoomOptions& options)
 {
+    ensureRoom();
     return room_->Connect(url.toStdString(), token.toStdString(), options);
 }
 
 void RoomController::reset()
 {
     room_.reset();
+    ensureRoom();
 }
 
 livekit::RoomInfoData RoomController::roomInfo() const
@@ -52,4 +54,16 @@ livekit::LocalParticipant* RoomController::localParticipant() const
 std::vector<std::shared_ptr<livekit::RemoteParticipant>> RoomController::remoteParticipants() const
 {
     return room_ ? room_->remoteParticipants() : std::vector<std::shared_ptr<livekit::RemoteParticipant>>{};
+}
+
+void RoomController::ensureRoom()
+{
+    if (room_) {
+        return;
+    }
+
+    room_ = std::make_unique<livekit::Room>();
+    if (delegate_) {
+        room_->setDelegate(delegate_);
+    }
 }

--- a/core/conference/room_controller.h
+++ b/core/conference/room_controller.h
@@ -23,7 +23,10 @@ public:
     std::vector<std::shared_ptr<livekit::RemoteParticipant>> remoteParticipants() const;
 
 private:
+    void ensureRoom();
+
     std::unique_ptr<livekit::Room> room_;
+    livekit::RoomDelegate* delegate_{nullptr};
 };
 
 #endif // CORE_CONFERENCE_ROOM_CONTROLLER_H

--- a/core/room_event_delegate.cpp
+++ b/core/room_event_delegate.cpp
@@ -191,7 +191,17 @@ void RoomEventDelegate::onLocalTrackPublished(livekit::Room& room,
                                                const livekit::LocalTrackPublishedEvent& event)
 {
     Q_UNUSED(room);
-    Q_UNUSED(event);
-    // Log for debugging, actual handling is done synchronously in publish calls
-    Logger::instance().info("RoomEventDelegate: Local track published");
+    if (!event.publication) {
+        return;
+    }
+
+    const QString publicationSid = QString::fromStdString(event.publication->sid());
+    const int kind = static_cast<int>(event.publication->kind());
+    const int source = static_cast<int>(event.publication->source());
+
+    Logger::instance().info(QString("RoomEventDelegate: Local track published: sid=%1 source=%2")
+        .arg(publicationSid)
+        .arg(source));
+
+    emit localTrackPublishedQueued(publicationSid, kind, source);
 }

--- a/core/room_event_delegate.cpp
+++ b/core/room_event_delegate.cpp
@@ -1,6 +1,7 @@
 #include "room_event_delegate.h"
 #include "conference/participant_metadata_parser.h"
 #include "../utils/logger.h"
+#include "livekit/local_track_publication.h"
 #include "livekit/participant.h"
 #include "livekit/remote_participant.h"
 #include "livekit/remote_track_publication.h"

--- a/core/room_event_delegate.h
+++ b/core/room_event_delegate.h
@@ -57,6 +57,7 @@ signals:
     void connectionStateChangedQueued(int state);
     void roomDisconnectedQueued(int reason);
     void dataReceivedQueued(QByteArray data, QString participantIdentity, QString topic);
+    void localTrackPublishedQueued(QString publicationSid, int kind, int source);
 
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -131,7 +131,7 @@ int main(int argc, char* argv[])
     Logger::instance().init();
     Logger::instance().log("Application started");
 
-    livekit::initialize();
+    livekit::initialize(livekit::LogLevel::Info, livekit::LogSink::kConsole);
 
     qmlRegisterType<LoginBackend>("Links.Backend", 1, 0, "LoginBackend");
     qmlRegisterType<SettingsBackend>("Links.Backend", 1, 0, "SettingsBackend");


### PR DESCRIPTION
This pull request introduces several improvements to the handling of the LiveKit SDK integration, device track publishing/unpublishing, and conference connection management. The main focus is on making track management more robust and error-tolerant, improving SDK path resolution in CMake, and ensuring safer disconnect logic.

**Device Track Management Improvements:**

* Added utility functions (`resolveTrackPublication`, `resolvePublishedTrackSid`, `unpublishLocalTrack`) in `device_controller.cpp` to robustly resolve and unpublish local tracks, handling cases where track SIDs might not be immediately available and suppressing "track not found" errors where appropriate. All track unpublishing logic throughout the file now uses these helpers for consistency and reliability. [[1]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61R5-R113) [[2]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61L69-R187) [[3]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61L109-R250) [[4]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61L178-R308) [[5]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61L219-R355) [[6]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61L235-R369) [[7]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61L278-R414) [[8]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61L293-L298) [[9]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61L336-R467) [[10]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61L357-R492)

**Conference Connection and Disconnection Robustness:**

* Improved `ConferenceManager::disconnect()` to be idempotent and more robust: added a `disconnecting_` guard, granular try/catch blocks for each cleanup step, and a lambda to finalize state reset and signal emissions, ensuring all resources are cleaned up even if some steps fail. [[1]](diffhunk://#diff-d9f3e36a97851507ae21d5ef07e030727a2cd331947b09270c355afd041ae5d0R153-R222) [[2]](diffhunk://#diff-c802c3d9c4c87078f431d242701ba68670941a95947a912a5f918ae32346b307R156)
* Set `options.single_peer_connection = true` in `ConferenceManager::connect()` for improved connection behavior.

**CMake SDK Path Handling:**

* Enhanced `FetchLiveKitSDK.cmake` to support SDK archives with or without an extra top-level directory, and added explicit checks with clear error messages for missing `include/` or `lib/` directories and required binaries. All SDK path variables now resolve to the correct directory regardless of archive layout.
* Updated the default `LIVEKIT_SDK_VERSION` to `0.3.4`.
* Updated status messages to reflect the resolved SDK root.