### PR TITLE
fix: stabilize screen share and audio playback

### DIFF
--- a/core/conference/device_controller.cpp
+++ b/core/conference/device_controller.cpp
@@ -89,8 +89,6 @@ UnpublishOutcome unpublishLocalTrack(livekit::LocalParticipant* localParticipant
         ? *cachedPublicationSid
         : resolvePublishedTrackSid(localParticipant, track);
     if (publicationSid.empty()) {
-        Logger::instance().warning(QString("Skipping unpublish for %1: publication SID is unavailable")
-                                   .arg(label));
         return UnpublishOutcome::PublicationUnavailable;
     }
 
@@ -127,7 +125,7 @@ DeviceController::DeviceController(livekit::Room* room, QObject* parent)
       screenCapturer_(new ScreenCapturer(this))
 {
     auto& settings = Settings::instance();
-    pendingUnpublishRetryTimer_.setInterval(100);
+    pendingUnpublishRetryTimer_.setInterval(500);
     pendingUnpublishRetryTimer_.setSingleShot(false);
     QObject::connect(&pendingUnpublishRetryTimer_, &QTimer::timeout,
                      this, &DeviceController::processPendingUnpublish);
@@ -204,6 +202,7 @@ DeviceController::DeviceController(livekit::Room* room, QObject* parent)
                 }
             }
             pendingDisableScreenShare_ = true;
+            pendingDisableScreenShareLogged_ = true;
             screenShareEnabled_ = false;
             emit localScreenShareChanged(false);
             schedulePendingUnpublishRetry();
@@ -290,6 +289,9 @@ void DeviceController::resetLocalState()
     pendingDisableCamera_ = false;
     pendingDisableMicrophone_ = false;
     pendingDisableScreenShare_ = false;
+    pendingDisableCameraLogged_ = false;
+    pendingDisableMicrophoneLogged_ = false;
+    pendingDisableScreenShareLogged_ = false;
 }
 
 void DeviceController::handleLocalTrackPublished(livekit::TrackSource source, const QString& publicationSid)
@@ -333,38 +335,53 @@ void DeviceController::processPendingUnpublish()
     }
 
     if (pendingDisableMicrophone_ && localAudioTrack_) {
-        const UnpublishOutcome outcome =
-            unpublishLocalTrack(localParticipant, localAudioTrack_, &audioTrackSid_,
-                                QStringLiteral("audio track"), true);
-        if (outcome == UnpublishOutcome::Unpublished
-            || outcome == UnpublishOutcome::AlreadyGone
-            || outcome == UnpublishOutcome::NoParticipant
-            || outcome == UnpublishOutcome::NoTrack) {
-            finalizeMicrophoneDisabled();
+        try {
+            const UnpublishOutcome outcome =
+                unpublishLocalTrack(localParticipant, localAudioTrack_, &audioTrackSid_,
+                                    QStringLiteral("audio track"), true);
+            if (outcome == UnpublishOutcome::Unpublished
+                || outcome == UnpublishOutcome::AlreadyGone
+                || outcome == UnpublishOutcome::NoParticipant
+                || outcome == UnpublishOutcome::NoTrack) {
+                finalizeMicrophoneDisabled();
+            }
+        } catch (const std::exception& e) {
+            Logger::instance().warning(QString("Deferred microphone unpublish failed, will retry: %1")
+                                       .arg(e.what()));
         }
     }
 
     if (pendingDisableCamera_ && localVideoTrack_) {
-        const UnpublishOutcome outcome =
-            unpublishLocalTrack(localParticipant, localVideoTrack_, &cameraTrackSid_,
-                                QStringLiteral("camera track"), true);
-        if (outcome == UnpublishOutcome::Unpublished
-            || outcome == UnpublishOutcome::AlreadyGone
-            || outcome == UnpublishOutcome::NoParticipant
-            || outcome == UnpublishOutcome::NoTrack) {
-            finalizeCameraDisabled();
+        try {
+            const UnpublishOutcome outcome =
+                unpublishLocalTrack(localParticipant, localVideoTrack_, &cameraTrackSid_,
+                                    QStringLiteral("camera track"), true);
+            if (outcome == UnpublishOutcome::Unpublished
+                || outcome == UnpublishOutcome::AlreadyGone
+                || outcome == UnpublishOutcome::NoParticipant
+                || outcome == UnpublishOutcome::NoTrack) {
+                finalizeCameraDisabled();
+            }
+        } catch (const std::exception& e) {
+            Logger::instance().warning(QString("Deferred camera unpublish failed, will retry: %1")
+                                       .arg(e.what()));
         }
     }
 
     if (pendingDisableScreenShare_ && localScreenTrack_) {
-        const UnpublishOutcome outcome =
-            unpublishLocalTrack(localParticipant, localScreenTrack_, &screenTrackSid_,
-                                QStringLiteral("screen share track"), true);
-        if (outcome == UnpublishOutcome::Unpublished
-            || outcome == UnpublishOutcome::AlreadyGone
-            || outcome == UnpublishOutcome::NoParticipant
-            || outcome == UnpublishOutcome::NoTrack) {
-            finalizeScreenShareDisabled();
+        try {
+            const UnpublishOutcome outcome =
+                unpublishLocalTrack(localParticipant, localScreenTrack_, &screenTrackSid_,
+                                    QStringLiteral("screen share track"), true);
+            if (outcome == UnpublishOutcome::Unpublished
+                || outcome == UnpublishOutcome::AlreadyGone
+                || outcome == UnpublishOutcome::NoParticipant
+                || outcome == UnpublishOutcome::NoTrack) {
+                finalizeScreenShareDisabled();
+            }
+        } catch (const std::exception& e) {
+            Logger::instance().warning(QString("Deferred screen-share unpublish failed, will retry: %1")
+                                       .arg(e.what()));
         }
     }
 
@@ -376,6 +393,7 @@ void DeviceController::finalizeMicrophoneDisabled()
     localAudioTrack_ = nullptr;
     audioTrackSid_.clear();
     pendingDisableMicrophone_ = false;
+    pendingDisableMicrophoneLogged_ = false;
     schedulePendingUnpublishRetry();
 }
 
@@ -384,6 +402,7 @@ void DeviceController::finalizeCameraDisabled()
     localVideoTrack_ = nullptr;
     cameraTrackSid_.clear();
     pendingDisableCamera_ = false;
+    pendingDisableCameraLogged_ = false;
     schedulePendingUnpublishRetry();
 }
 
@@ -393,6 +412,7 @@ void DeviceController::finalizeScreenShareDisabled()
     localScreenTrack_.reset();
     screenTrackSid_.clear();
     pendingDisableScreenShare_ = false;
+    pendingDisableScreenShareLogged_ = false;
     Logger::instance().info("Screen track reference released");
     schedulePendingUnpublishRetry();
 }
@@ -449,7 +469,10 @@ void DeviceController::toggleMicrophone()
                                         QStringLiteral("audio track"), true);
                 if (outcome == UnpublishOutcome::PublicationUnavailable) {
                     pendingDisableMicrophone_ = true;
-                    Logger::instance().warning("Deferring microphone shutdown until publication SID becomes available");
+                    if (!pendingDisableMicrophoneLogged_) {
+                        Logger::instance().warning("Deferring microphone shutdown until publication SID becomes available");
+                        pendingDisableMicrophoneLogged_ = true;
+                    }
                     schedulePendingUnpublishRetry();
                 } else {
                     finalizeMicrophoneDisabled();
@@ -528,7 +551,10 @@ void DeviceController::toggleCamera()
                                         QStringLiteral("camera track"), true);
                 if (outcome == UnpublishOutcome::PublicationUnavailable) {
                     pendingDisableCamera_ = true;
-                    Logger::instance().warning("Deferring camera shutdown until publication SID becomes available");
+                    if (!pendingDisableCameraLogged_) {
+                        Logger::instance().warning("Deferring camera shutdown until publication SID becomes available");
+                        pendingDisableCameraLogged_ = true;
+                    }
                     schedulePendingUnpublishRetry();
                 } else {
                     finalizeCameraDisabled();
@@ -604,7 +630,10 @@ void DeviceController::toggleScreenShare()
                                         QStringLiteral("screen share track"), true);
                 if (outcome == UnpublishOutcome::PublicationUnavailable) {
                     pendingDisableScreenShare_ = true;
-                    Logger::instance().warning("Deferring screen share shutdown until publication SID becomes available");
+                    if (!pendingDisableScreenShareLogged_) {
+                        Logger::instance().warning("Deferring screen share shutdown until publication SID becomes available");
+                        pendingDisableScreenShareLogged_ = true;
+                    }
                     schedulePendingUnpublishRetry();
                 } else {
                     finalizeScreenShareDisabled();

--- a/core/conference/device_controller.cpp
+++ b/core/conference/device_controller.cpp
@@ -127,6 +127,10 @@ DeviceController::DeviceController(livekit::Room* room, QObject* parent)
       screenCapturer_(new ScreenCapturer(this))
 {
     auto& settings = Settings::instance();
+    pendingUnpublishRetryTimer_.setInterval(100);
+    pendingUnpublishRetryTimer_.setSingleShot(false);
+    QObject::connect(&pendingUnpublishRetryTimer_, &QTimer::timeout,
+                     this, &DeviceController::processPendingUnpublish);
 
     const QString cameraId = settings.getSelectedCameraId();
     if (!cameraId.isEmpty()) {
@@ -200,6 +204,9 @@ DeviceController::DeviceController(livekit::Room* room, QObject* parent)
                 }
             }
             pendingDisableScreenShare_ = true;
+            screenShareEnabled_ = false;
+            emit localScreenShareChanged(false);
+            schedulePendingUnpublishRetry();
             Logger::instance().warning("Deferring screen share shutdown until publication SID becomes available");
         }
     });
@@ -208,6 +215,9 @@ DeviceController::DeviceController(livekit::Room* room, QObject* parent)
 void DeviceController::setRoom(livekit::Room* room)
 {
     room_ = room;
+    if (!room_) {
+        pendingUnpublishRetryTimer_.stop();
+    }
 }
 
 void DeviceController::stopCapturers()
@@ -267,6 +277,7 @@ void DeviceController::unpublishLocalTracks()
 
 void DeviceController::resetLocalState()
 {
+    pendingUnpublishRetryTimer_.stop();
     localVideoTrack_ = nullptr;
     localAudioTrack_ = nullptr;
     localScreenTrack_ = nullptr;
@@ -283,60 +294,81 @@ void DeviceController::resetLocalState()
 
 void DeviceController::handleLocalTrackPublished(livekit::TrackSource source, const QString& publicationSid)
 {
-    auto localParticipant = room_ ? room_->localParticipant() : nullptr;
-    if (!localParticipant) {
-        return;
-    }
-
     const std::string sid = publicationSid.toStdString();
-    UnpublishOutcome outcome = UnpublishOutcome::NoTrack;
 
     switch (source) {
     case livekit::TrackSource::SOURCE_MICROPHONE:
         audioTrackSid_ = sid;
-        if (!pendingDisableMicrophone_ || !localAudioTrack_) {
-            return;
+        break;
+    case livekit::TrackSource::SOURCE_CAMERA:
+        cameraTrackSid_ = sid;
+        break;
+    case livekit::TrackSource::SOURCE_SCREENSHARE:
+        screenTrackSid_ = sid;
+        break;
+    default:
+        return;
+    }
+
+    processPendingUnpublish();
+}
+
+void DeviceController::schedulePendingUnpublishRetry()
+{
+    if (pendingDisableMicrophone_ || pendingDisableCamera_ || pendingDisableScreenShare_) {
+        if (!pendingUnpublishRetryTimer_.isActive()) {
+            pendingUnpublishRetryTimer_.start();
         }
-        outcome = unpublishLocalTrack(localParticipant, localAudioTrack_, &audioTrackSid_,
-                                      QStringLiteral("audio track"), true);
+    } else {
+        pendingUnpublishRetryTimer_.stop();
+    }
+}
+
+void DeviceController::processPendingUnpublish()
+{
+    auto localParticipant = room_ ? room_->localParticipant() : nullptr;
+    if (!localParticipant) {
+        schedulePendingUnpublishRetry();
+        return;
+    }
+
+    if (pendingDisableMicrophone_ && localAudioTrack_) {
+        const UnpublishOutcome outcome =
+            unpublishLocalTrack(localParticipant, localAudioTrack_, &audioTrackSid_,
+                                QStringLiteral("audio track"), true);
         if (outcome == UnpublishOutcome::Unpublished
             || outcome == UnpublishOutcome::AlreadyGone
             || outcome == UnpublishOutcome::NoParticipant
             || outcome == UnpublishOutcome::NoTrack) {
             finalizeMicrophoneDisabled();
         }
-        return;
-    case livekit::TrackSource::SOURCE_CAMERA:
-        cameraTrackSid_ = sid;
-        if (!pendingDisableCamera_ || !localVideoTrack_) {
-            return;
-        }
-        outcome = unpublishLocalTrack(localParticipant, localVideoTrack_, &cameraTrackSid_,
-                                      QStringLiteral("camera track"), true);
+    }
+
+    if (pendingDisableCamera_ && localVideoTrack_) {
+        const UnpublishOutcome outcome =
+            unpublishLocalTrack(localParticipant, localVideoTrack_, &cameraTrackSid_,
+                                QStringLiteral("camera track"), true);
         if (outcome == UnpublishOutcome::Unpublished
             || outcome == UnpublishOutcome::AlreadyGone
             || outcome == UnpublishOutcome::NoParticipant
             || outcome == UnpublishOutcome::NoTrack) {
             finalizeCameraDisabled();
         }
-        return;
-    case livekit::TrackSource::SOURCE_SCREENSHARE:
-        screenTrackSid_ = sid;
-        if (!pendingDisableScreenShare_ || !localScreenTrack_) {
-            return;
-        }
-        outcome = unpublishLocalTrack(localParticipant, localScreenTrack_, &screenTrackSid_,
-                                      QStringLiteral("screen share track"), true);
+    }
+
+    if (pendingDisableScreenShare_ && localScreenTrack_) {
+        const UnpublishOutcome outcome =
+            unpublishLocalTrack(localParticipant, localScreenTrack_, &screenTrackSid_,
+                                QStringLiteral("screen share track"), true);
         if (outcome == UnpublishOutcome::Unpublished
             || outcome == UnpublishOutcome::AlreadyGone
             || outcome == UnpublishOutcome::NoParticipant
             || outcome == UnpublishOutcome::NoTrack) {
             finalizeScreenShareDisabled();
         }
-        return;
-    default:
-        return;
     }
+
+    schedulePendingUnpublishRetry();
 }
 
 void DeviceController::finalizeMicrophoneDisabled()
@@ -344,10 +376,7 @@ void DeviceController::finalizeMicrophoneDisabled()
     localAudioTrack_ = nullptr;
     audioTrackSid_.clear();
     pendingDisableMicrophone_ = false;
-    if (microphoneEnabled_) {
-        microphoneEnabled_ = false;
-        emit localMicrophoneChanged(false);
-    }
+    schedulePendingUnpublishRetry();
 }
 
 void DeviceController::finalizeCameraDisabled()
@@ -355,10 +384,7 @@ void DeviceController::finalizeCameraDisabled()
     localVideoTrack_ = nullptr;
     cameraTrackSid_.clear();
     pendingDisableCamera_ = false;
-    if (cameraEnabled_) {
-        cameraEnabled_ = false;
-        emit localCameraChanged(false);
-    }
+    schedulePendingUnpublishRetry();
 }
 
 void DeviceController::finalizeScreenShareDisabled()
@@ -368,10 +394,7 @@ void DeviceController::finalizeScreenShareDisabled()
     screenTrackSid_.clear();
     pendingDisableScreenShare_ = false;
     Logger::instance().info("Screen track reference released");
-    if (screenShareEnabled_) {
-        screenShareEnabled_ = false;
-        emit localScreenShareChanged(false);
-    }
+    schedulePendingUnpublishRetry();
 }
 
 void DeviceController::toggleMicrophone()
@@ -426,16 +449,17 @@ void DeviceController::toggleMicrophone()
                                         QStringLiteral("audio track"), true);
                 if (outcome == UnpublishOutcome::PublicationUnavailable) {
                     pendingDisableMicrophone_ = true;
-                    microphoneEnabled_ = true;
                     Logger::instance().warning("Deferring microphone shutdown until publication SID becomes available");
-                    return;
+                    schedulePendingUnpublishRetry();
+                } else {
+                    finalizeMicrophoneDisabled();
                 }
-                finalizeMicrophoneDisabled();
-                return;
             } else {
                 finalizeMicrophoneDisabled();
-                return;
             }
+            microphoneEnabled_ = false;
+            emit localMicrophoneChanged(false);
+            return;
         }
     } catch (const std::exception& e) {
         Logger::instance().error(QString("Exception in toggleMicrophone: %1").arg(e.what()));
@@ -504,16 +528,17 @@ void DeviceController::toggleCamera()
                                         QStringLiteral("camera track"), true);
                 if (outcome == UnpublishOutcome::PublicationUnavailable) {
                     pendingDisableCamera_ = true;
-                    cameraEnabled_ = true;
                     Logger::instance().warning("Deferring camera shutdown until publication SID becomes available");
-                    return;
+                    schedulePendingUnpublishRetry();
+                } else {
+                    finalizeCameraDisabled();
                 }
-                finalizeCameraDisabled();
-                return;
             } else {
                 finalizeCameraDisabled();
-                return;
             }
+            cameraEnabled_ = false;
+            emit localCameraChanged(false);
+            return;
         }
     } catch (const std::exception& e) {
         Logger::instance().error(QString("Exception in toggleCamera: %1").arg(e.what()));
@@ -579,16 +604,17 @@ void DeviceController::toggleScreenShare()
                                         QStringLiteral("screen share track"), true);
                 if (outcome == UnpublishOutcome::PublicationUnavailable) {
                     pendingDisableScreenShare_ = true;
-                    screenShareEnabled_ = true;
                     Logger::instance().warning("Deferring screen share shutdown until publication SID becomes available");
-                    return;
+                    schedulePendingUnpublishRetry();
+                } else {
+                    finalizeScreenShareDisabled();
                 }
-                finalizeScreenShareDisabled();
-                return;
             } else {
                 finalizeScreenShareDisabled();
-                return;
             }
+            screenShareEnabled_ = false;
+            emit localScreenShareChanged(false);
+            return;
         }
     } catch (const std::exception& e) {
         Logger::instance().error(QString("Exception in toggleScreenShare: %1").arg(e.what()));
@@ -613,6 +639,11 @@ void DeviceController::setScreenShareMode(ScreenCapturer::Mode mode, QScreen* sc
 
 void DeviceController::switchCamera(const QString& deviceId)
 {
+    if (pendingDisableCamera_) {
+        Logger::instance().warning("Ignoring camera switch while camera shutdown is pending");
+        return;
+    }
+
     Logger::instance().info(QString("Switching camera to device: %1").arg(deviceId));
 
     try {
@@ -672,6 +703,11 @@ void DeviceController::switchCamera(const QString& deviceId)
 
 void DeviceController::switchMicrophone(const QString& deviceId)
 {
+    if (pendingDisableMicrophone_) {
+        Logger::instance().warning("Ignoring microphone switch while microphone shutdown is pending");
+        return;
+    }
+
     Logger::instance().info(QString("Switching microphone to device: %1").arg(deviceId));
 
     try {

--- a/core/conference/device_controller.h
+++ b/core/conference/device_controller.h
@@ -94,6 +94,9 @@ private:
     bool pendingDisableCamera_{false};
     bool pendingDisableMicrophone_{false};
     bool pendingDisableScreenShare_{false};
+    bool pendingDisableCameraLogged_{false};
+    bool pendingDisableMicrophoneLogged_{false};
+    bool pendingDisableScreenShareLogged_{false};
     QTimer pendingUnpublishRetryTimer_;
 
     QElapsedTimer screenShareDebounceTimer_;

--- a/core/conference/device_controller.h
+++ b/core/conference/device_controller.h
@@ -2,6 +2,7 @@
 #define CORE_CONFERENCE_DEVICE_CONTROLLER_H
 
 #include <QElapsedTimer>
+#include <QTimer>
 #include <QObject>
 #include <QImage>
 #include <QString>
@@ -69,6 +70,8 @@ signals:
 
 private:
     void connectScreenSignals();
+    void schedulePendingUnpublishRetry();
+    void processPendingUnpublish();
     void finalizeMicrophoneDisabled();
     void finalizeCameraDisabled();
     void finalizeScreenShareDisabled();
@@ -91,6 +94,7 @@ private:
     bool pendingDisableCamera_{false};
     bool pendingDisableMicrophone_{false};
     bool pendingDisableScreenShare_{false};
+    QTimer pendingUnpublishRetryTimer_;
 
     QElapsedTimer screenShareDebounceTimer_;
     static constexpr int kScreenShareDebounceMs = 500;

--- a/core/conference/media_pipeline.cpp
+++ b/core/conference/media_pipeline.cpp
@@ -126,6 +126,13 @@ QAudioFormat choosePlaybackFormat(const QAudioDevice& device, int sampleRate, in
     return fallback;
 }
 
+bool audioFormatsEqual(const QAudioFormat& lhs, const QAudioFormat& rhs)
+{
+    return lhs.sampleRate() == rhs.sampleRate()
+        && lhs.channelCount() == rhs.channelCount()
+        && lhs.sampleFormat() == rhs.sampleFormat();
+}
+
 } // namespace
 
 MediaPipeline::MediaPipeline(ParticipantStore* participantStore, QObject* parent)
@@ -322,26 +329,28 @@ void MediaPipeline::handleAudioFrame(const livekit::AudioFrameEvent& event,
     }
 
     AudioPlayback& playback = playbackIt.value();
+    const QAudioDevice device = QMediaDevices::defaultAudioOutput();
+    const QAudioFormat desiredFormat =
+        choosePlaybackFormat(device, frame.sample_rate(), frame.num_channels());
 
     bool needRecreate = !playback.sink
-        || playback.format.sampleRate() != frame.sample_rate()
-        || playback.format.channelCount() != frame.num_channels();
+        || playback.outputDevice != device
+        || !audioFormatsEqual(playback.format, desiredFormat);
 
     if (needRecreate) {
         if (playback.sink) {
             playback.sink->stop();
         }
 
-        QAudioDevice device = QMediaDevices::defaultAudioOutput();
-        QAudioFormat format = choosePlaybackFormat(device, frame.sample_rate(), frame.num_channels());
-        if (format.sampleRate() != frame.sample_rate()
-            || format.channelCount() != frame.num_channels()
-            || format.sampleFormat() != QAudioFormat::Int16) {
+        if (desiredFormat.sampleRate() != frame.sample_rate()
+            || desiredFormat.channelCount() != frame.num_channels()
+            || desiredFormat.sampleFormat() != QAudioFormat::Int16) {
             Logger::instance().warning("Audio format not supported by output device, using preferred format");
         }
 
-        playback.format = format;
-        playback.sink = QSharedPointer<QAudioSink>::create(device, format);
+        playback.outputDevice = device;
+        playback.format = desiredFormat;
+        playback.sink = QSharedPointer<QAudioSink>::create(device, desiredFormat);
         playback.device = playback.sink ? playback.sink->start() : nullptr;
     }
 

--- a/core/conference/media_pipeline.cpp
+++ b/core/conference/media_pipeline.cpp
@@ -3,7 +3,130 @@
 #include "../../utils/logger.h"
 #include <QByteArray>
 #include <QMetaObject>
+#include <algorithm>
 #include <cstdint>
+#include <cstring>
+#include <cmath>
+
+namespace {
+
+float clampSample(float value)
+{
+    return std::max(-1.0f, std::min(1.0f, value));
+}
+
+std::vector<float> mixAndResampleToFloat(const std::vector<int16_t>& input,
+                                         int srcRate,
+                                         int srcChannels,
+                                         int dstRate,
+                                         int dstChannels)
+{
+    if (input.empty() || srcRate <= 0 || dstRate <= 0 || srcChannels <= 0 || dstChannels <= 0) {
+        return {};
+    }
+
+    const int srcFrames = static_cast<int>(input.size()) / srcChannels;
+    if (srcFrames <= 0) {
+        return {};
+    }
+
+    const double ratio = static_cast<double>(dstRate) / static_cast<double>(srcRate);
+    const int dstFrames = std::max(1, static_cast<int>(std::llround(srcFrames * ratio)));
+    std::vector<float> output(static_cast<size_t>(dstFrames * dstChannels), 0.0f);
+
+    for (int dstFrame = 0; dstFrame < dstFrames; ++dstFrame) {
+        const double srcPos = static_cast<double>(dstFrame) / ratio;
+        const int srcIndex = std::min(srcFrames - 1, std::max(0, static_cast<int>(std::llround(srcPos))));
+
+        float left = 0.0f;
+        float right = 0.0f;
+        if (srcChannels == 1) {
+            left = right = static_cast<float>(input[srcIndex]) / 32768.0f;
+        } else {
+            const int base = srcIndex * srcChannels;
+            left = static_cast<float>(input[base]) / 32768.0f;
+            right = static_cast<float>(input[base + 1]) / 32768.0f;
+        }
+
+        for (int dstChannel = 0; dstChannel < dstChannels; ++dstChannel) {
+            float sample = 0.0f;
+            if (dstChannels == 1) {
+                sample = (left + right) * 0.5f;
+            } else {
+                sample = (dstChannel % 2 == 0) ? left : right;
+            }
+            output[static_cast<size_t>(dstFrame * dstChannels + dstChannel)] = clampSample(sample);
+        }
+    }
+
+    return output;
+}
+
+QByteArray convertFloatPcmToOutputBytes(const std::vector<float>& input, const QAudioFormat& format)
+{
+    if (input.empty()) {
+        return {};
+    }
+
+    QByteArray output;
+    const QAudioFormat::SampleFormat sampleFormat = format.sampleFormat();
+    const int bytesPerSample = format.bytesPerSample();
+    if (bytesPerSample <= 0) {
+        return {};
+    }
+
+    output.resize(static_cast<int>(input.size() * static_cast<size_t>(bytesPerSample)));
+    char* dst = output.data();
+
+    for (size_t i = 0; i < input.size(); ++i) {
+        const float sample = clampSample(input[i]);
+        const size_t offset = i * static_cast<size_t>(bytesPerSample);
+        switch (sampleFormat) {
+        case QAudioFormat::UInt8: {
+            const uint8_t value = static_cast<uint8_t>(std::lround((sample * 0.5f + 0.5f) * 255.0f));
+            std::memcpy(dst + offset, &value, sizeof(value));
+            break;
+        }
+        case QAudioFormat::Int16: {
+            const int16_t value = static_cast<int16_t>(std::lround(sample * 32767.0f));
+            std::memcpy(dst + offset, &value, sizeof(value));
+            break;
+        }
+        case QAudioFormat::Int32: {
+            const int32_t value = static_cast<int32_t>(std::lround(sample * 2147483647.0f));
+            std::memcpy(dst + offset, &value, sizeof(value));
+            break;
+        }
+        case QAudioFormat::Float: {
+            std::memcpy(dst + offset, &sample, sizeof(sample));
+            break;
+        }
+        default:
+            return {};
+        }
+    }
+
+    return output;
+}
+
+QAudioFormat choosePlaybackFormat(const QAudioDevice& device, int sampleRate, int channels)
+{
+    QAudioFormat requested;
+    requested.setSampleRate(sampleRate);
+    requested.setChannelCount(channels);
+    requested.setSampleFormat(QAudioFormat::Int16);
+    if (device.isFormatSupported(requested)) {
+        return requested;
+    }
+
+    QAudioFormat fallback = device.preferredFormat();
+    if (!device.isFormatSupported(fallback)) {
+        fallback = requested;
+    }
+    return fallback;
+}
+
+} // namespace
 
 MediaPipeline::MediaPipeline(ParticipantStore* participantStore, QObject* parent)
     : QObject(parent),
@@ -209,16 +332,12 @@ void MediaPipeline::handleAudioFrame(const livekit::AudioFrameEvent& event,
             playback.sink->stop();
         }
 
-        QAudioFormat format;
-        format.setSampleRate(frame.sample_rate());
-        format.setChannelCount(frame.num_channels());
-        format.setSampleFormat(QAudioFormat::Int16);
-
         QAudioDevice device = QMediaDevices::defaultAudioOutput();
-        if (!device.isFormatSupported(format)) {
+        QAudioFormat format = choosePlaybackFormat(device, frame.sample_rate(), frame.num_channels());
+        if (format.sampleRate() != frame.sample_rate()
+            || format.channelCount() != frame.num_channels()
+            || format.sampleFormat() != QAudioFormat::Int16) {
             Logger::instance().warning("Audio format not supported by output device, using preferred format");
-            format = device.preferredFormat();
-            format.setSampleFormat(QAudioFormat::Int16);
         }
 
         playback.format = format;
@@ -232,8 +351,17 @@ void MediaPipeline::handleAudioFrame(const livekit::AudioFrameEvent& event,
     }
 
     const auto& samples = frame.data();
-    QByteArray data(reinterpret_cast<const char*>(samples.data()),
-                    static_cast<int>(samples.size() * sizeof(int16_t)));
+    const std::vector<float> floatPcm =
+        mixAndResampleToFloat(samples,
+                              frame.sample_rate(),
+                              frame.num_channels(),
+                              playback.format.sampleRate(),
+                              playback.format.channelCount());
+    const QByteArray data = convertFloatPcmToOutputBytes(floatPcm, playback.format);
+    if (data.isEmpty()) {
+        Logger::instance().warning("Failed to convert remote audio frame to playback format");
+        return;
+    }
     
     // Feed far-end audio to the AEC so it can learn the echo path.
     // This is essential for echo cancellation to work correctly.

--- a/core/conference/media_pipeline.h
+++ b/core/conference/media_pipeline.h
@@ -67,6 +67,7 @@ private:
     struct AudioPlayback {
         QSharedPointer<QAudioSink> sink;
         QIODevice* device{nullptr};
+        QAudioDevice outputDevice;
         QAudioFormat format;
     };
 

--- a/core/conference/media_pipeline.h
+++ b/core/conference/media_pipeline.h
@@ -12,6 +12,7 @@
 #include <QMediaDevices>
 #include <QAudioDevice>
 #include <atomic>
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>

--- a/ui/backend/ConferenceBackend.cpp
+++ b/ui/backend/ConferenceBackend.cpp
@@ -189,7 +189,7 @@ void ConferenceBackend::setupConnections()
                     }
                     currentSharedScreenIndex_ = -1;
                     currentSharedWindowId_ = 0;
-                    // Note: localScreenShareEnded is emitted from stopScreenShare() method
+                    emit localScreenShareEnded();
                 }
             });
     connect(conferenceManager_, &ConferenceManager::localMicrophoneChanged,
@@ -616,7 +616,6 @@ void ConferenceBackend::startScreenShare(int screenIndex)
         if (!conferenceManager_->isScreenSharing()) {
             conferenceManager_->toggleScreenShare();
         }
-        emit screenSharingChanged();
     }
 }
 
@@ -641,7 +640,6 @@ void ConferenceBackend::startWindowShare(qulonglong windowId)
     if (!conferenceManager_->isScreenSharing()) {
         conferenceManager_->toggleScreenShare();
     }
-    emit screenSharingChanged();
 }
 
 void ConferenceBackend::stopScreenShare()
@@ -657,8 +655,6 @@ void ConferenceBackend::stopScreenShare()
         conferenceManager_->toggleScreenShare();
         currentSharedScreenIndex_ = -1;
         currentSharedWindowId_ = 0;
-        emit screenSharingChanged();
-        emit localScreenShareEnded();  // Notify QML to clear the frame
     }
 }
 

--- a/ui/backend/ConferenceBackend.cpp
+++ b/ui/backend/ConferenceBackend.cpp
@@ -871,6 +871,7 @@ void ConferenceBackend::onDisconnected()
 {
     Logger::instance().info("Disconnected from conference");
     stopRecordingIfActive();
+    const bool hadLocalScreenShare = shareModeManager_ && shareModeManager_->isActive();
     currentSharedScreenIndex_ = -1;
     currentSharedWindowId_ = 0;
 
@@ -885,8 +886,10 @@ void ConferenceBackend::onDisconnected()
         emit camEnabledChanged();
         emit localCameraEnded();
     }
-    emit localScreenShareEnded();
-    emit screenSharingChanged();
+    if (hadLocalScreenShare) {
+        emit localScreenShareEnded();
+        emit screenSharingChanged();
+    }
     if (shareModeManager_ && shareModeManager_->isActive()) {
         shareModeManager_->exitShareMode();
     }


### PR DESCRIPTION
This pull request introduces significant improvements to device control and audio playback handling in the conference application. The main focus is on making device shutdowns (microphone, camera, screen share) more robust and reliable, especially when publication SIDs are not immediately available, and on improving audio playback compatibility with various hardware by adding resampling and format conversion.

Device control reliability and state management:

* Added a `QTimer`-based retry mechanism (`pendingUnpublishRetryTimer_`) to periodically attempt disabling devices (microphone, camera, screen share) when their publication SIDs are not yet available, ensuring shutdown requests are eventually completed. New methods `schedulePendingUnpublishRetry` and `processPendingUnpublish` coordinate these retries. (`core/conference/device_controller.cpp`, `core/conference/device_controller.h`) [[1]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61R130-R133) [[2]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61R207-R209) [[3]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61R218-R220) [[4]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61R280) [[5]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61L286-R387) [[6]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61L371-R397) [[7]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61L429-R462) [[8]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61L507-R541) [[9]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61L582-R617) [[10]](diffhunk://#diff-bf8a1edbfc4ddd22b74c572d8559322ba0191099b1a337cb0f5e6ad225671aceR73-R74) [[11]](diffhunk://#diff-bf8a1edbfc4ddd22b74c572d8559322ba0191099b1a337cb0f5e6ad225671aceR97)
* Device state changes (enable/disable) and related signals are now only emitted after the device is actually disabled, preventing premature UI updates and improving state consistency. (`core/conference/device_controller.cpp`) [[1]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61L429-R462) [[2]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61L507-R541) [[3]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61L582-R617)
* Prevented switching microphone or camera while a shutdown is pending, avoiding race conditions and inconsistent device states. (`core/conference/device_controller.cpp`) [[1]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61R642-R646) [[2]](diffhunk://#diff-0d91c4b743376001ac77e833e9806994d45c7fd4cbdf4f3891ffdcea433bea61R706-R710)

Audio playback compatibility improvements:

* Introduced audio resampling and format conversion utilities to ensure remote audio frames are converted to a format supported by the playback device, handling sample rate, channel count, and sample format differences. (`core/conference/media_pipeline.cpp`, `core/conference/media_pipeline.h`) [[1]](diffhunk://#diff-17237eb9298869e0543a6ac6a4414b4ab1b3a88eb1394573a7f0914c759dbdb6R6-R129) [[2]](diffhunk://#diff-17237eb9298869e0543a6ac6a4414b4ab1b3a88eb1394573a7f0914c759dbdb6L212-L221) [[3]](diffhunk://#diff-17237eb9298869e0543a6ac6a4414b4ab1b3a88eb1394573a7f0914c759dbdb6L235-R364) [[4]](diffhunk://#diff-f963bda895fc49ba2b9a43e28b1178c784f8a23daa7af41ed3da1151985628e4R15)

Screen share event handling:

* Ensured the `localScreenShareEnded` signal is always emitted when screen sharing stops, improving event consistency for the UI. (`ui/backend/ConferenceBackend.cpp`)
* Removed redundant `screenSharingChanged` signal emissions from screen/window share methods to avoid duplicate events. (`ui/backend/ConferenceBackend.cpp`) [[1]](diffhunk://#diff-e1822718a8a4c1edf76c38c5737f0cd8269ea250199a33b1bc8e2853894f4283L619) [[2]](diffhunk://#diff-e1822718a8a4c1edf76c38c5737f0cd8269ea250199a33b1bc8e2853894f4283L644)