### PR TITLE
fix: sync connected state after room join

### DIFF
--- a/core/conference/conference_manager.cpp
+++ b/core/conference/conference_manager.cpp
@@ -139,6 +139,7 @@ void ConferenceManager::connect(const QString& url, const QString& token)
 
         if (success) {
             Logger::instance().info("Connection initiated successfully");
+            markConnected("connect_success", true);
         } else {
             Logger::instance().error("Connection failed");
             emit connectionError("Failed to connect to room");
@@ -652,24 +653,7 @@ void ConferenceManager::onConnectionStateChangedQueued(int state)
     Logger::instance().info(QString("Connection state changed: %1").arg(state));
 
     if (connState == livekit::ConnectionState::Connected) {
-        connected_ = true;
-
-        const auto roomInfo = roomController_->roomInfo();
-        roomName_ = QString::fromStdString(roomInfo.name);
-
-        auto localParticipant = roomController_->localParticipant();
-        if (localParticipant) {
-            participantName_ = QString::fromStdString(localParticipant->name());
-            participantIdentity_ = QString::fromStdString(localParticipant->identity());
-        }
-
-        reconcileParticipantsInternal("connection_connected_state");
-        if (!networkStatsTimer_.isActive()) {
-            networkStatsTimer_.start();
-        }
-        pollLocalNetworkStats();
-
-        emit connected();
+        markConnected("connection_connected_state", false);
     } else if (connState == livekit::ConnectionState::Reconnecting) {
         networkStatsTimer_.stop();
         resetNetworkMetrics();
@@ -704,6 +688,34 @@ void ConferenceManager::onConnectionStateChangedQueued(int state)
     }
 
     emit connectionStateChanged(connState);
+}
+
+void ConferenceManager::markConnected(const char* source, bool emitStateSignal)
+{
+    const bool wasConnected = connected_;
+    connected_ = true;
+
+    const auto roomInfo = roomController_->roomInfo();
+    roomName_ = QString::fromStdString(roomInfo.name);
+
+    auto localParticipant = roomController_->localParticipant();
+    if (localParticipant) {
+        participantName_ = QString::fromStdString(localParticipant->name());
+        participantIdentity_ = QString::fromStdString(localParticipant->identity());
+    }
+
+    reconcileParticipantsInternal(source);
+    if (!networkStatsTimer_.isActive()) {
+        networkStatsTimer_.start();
+    }
+    pollLocalNetworkStats();
+
+    if (!wasConnected) {
+        emit connected();
+        if (emitStateSignal) {
+            emit connectionStateChanged(livekit::ConnectionState::Connected);
+        }
+    }
 }
 
 void ConferenceManager::onRoomDisconnectedQueued(int reason)

--- a/core/conference/conference_manager.h
+++ b/core/conference/conference_manager.h
@@ -138,6 +138,7 @@ private:
     
     void updateParticipantInfo(const QString& identity);
     void reconcileParticipantsInternal(const char* source);
+    void markConnected(const char* source, bool emitStateSignal);
     void pollLocalNetworkStats();
     QString resolveLocalParticipantIdentity() const;
     std::vector<std::shared_ptr<livekit::Track>> collectTrackStatsSources() const;


### PR DESCRIPTION
This pull request refactors how the `ConferenceManager` class handles connection state changes by introducing a new helper method to centralize and streamline the logic for marking a connection as established. This reduces code duplication and improves maintainability.

**Connection State Handling Refactor:**

* Added a new method `markConnected` to `ConferenceManager` that encapsulates all logic for setting the connected state, updating participant and room info, starting network stats, and emitting relevant signals. [[1]](diffhunk://#diff-d9f3e36a97851507ae21d5ef07e030727a2cd331947b09270c355afd041ae5d0R693-R720) [[2]](diffhunk://#diff-c802c3d9c4c87078f431d242701ba68670941a95947a912a5f918ae32346b307R141)
* Updated both `connect` and `onConnectionStateChangedQueued` methods to use `markConnected`, removing duplicated code and ensuring consistent connection handling. [[1]](diffhunk://#diff-d9f3e36a97851507ae21d5ef07e030727a2cd331947b09270c355afd041ae5d0R142) [[2]](diffhunk://#diff-d9f3e36a97851507ae21d5ef07e030727a2cd331947b09270c355afd041ae5d0L655-R656)

No functional changes are expected, but the code is now more organized and less error-prone.